### PR TITLE
Implement remaining workflow engine issues (#2–#10)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -155,6 +155,69 @@ src
     - Once tasks are done, the workflow is marked as `completed`.
 
 
+### **End-to-End Demo — Fan-in Workflow**
+
+The shipped `src/workflows/example_workflow.yml` is a three-step fan-in:
+`polygonArea` and `analysis` run in parallel; `reportGeneration` depends
+on both and runs once they complete. `POST /analysis` drives the full
+pipeline end to end.
+
+1. **Submit a workflow** — returns a `workflowId` (202):
+    ```bash
+    curl -X POST http://localhost:3000/analysis \
+      -H "Content-Type: application/json" \
+      -d '{
+        "clientId": "demo",
+        "geoJson": {
+          "type": "Polygon",
+          "coordinates": [[
+            [-63.624885020050996, -10.311050368263523],
+            [-63.624885020050996, -10.367865108370523],
+            [-63.61278302732815,  -10.367865108370523],
+            [-63.61278302732815,  -10.311050368263523],
+            [-63.624885020050996, -10.311050368263523]
+          ]]
+        }
+      }'
+    # => { "workflowId": "<id>", "message": "Workflow created and tasks queued from YAML definition." }
+    ```
+
+2. **Poll status** — shows `in_progress` while running, `completed`
+   after `reportGeneration` finishes:
+    ```bash
+    curl http://localhost:3000/workflow/<id>/status
+    # => { "workflowId": "<id>", "status": "completed", "completedTasks": 3, "totalTasks": 3 }
+    ```
+
+3. **Per-task breakdown** — opt-in with `?includeTasks=true`:
+    ```bash
+    curl 'http://localhost:3000/workflow/<id>/status?includeTasks=true'
+    # => { …, "tasks": [
+    #      { "stepNumber": 1, "taskType": "polygonArea",     "status": "completed", "output": <area> },
+    #      { "stepNumber": 2, "taskType": "analysis",        "status": "completed", "output": "<country>" },
+    #      { "stepNumber": 3, "taskType": "reportGeneration","status": "completed", "output": { … } }
+    #    ] }
+    ```
+
+4. **Final results** — `finalResult` with all three tasks' outputs,
+   ordered by `stepNumber`:
+    ```bash
+    curl http://localhost:3000/workflow/<id>/results
+    # => { "workflowId": "<id>", "status": "completed",
+    #      "completedTasks": 3, "totalTasks": 3,
+    #      "tasks": [
+    #        { "stepNumber": 1, "taskType": "polygonArea",     "status": "completed", "output": <area> },
+    #        { "stepNumber": 2, "taskType": "analysis",        "status": "completed", "output": "<country>" },
+    #        { "stepNumber": 3, "taskType": "reportGeneration","status": "completed",
+    #          "output": { "workflowId": "<id>", "tasks": [<polygonArea>, <analysis>], "finalReport": "…" } }
+    #      ] }
+    ```
+
+The `reportGeneration` entry's `output.tasks` contains its two
+dependencies (`polygonArea`, `analysis`) — it aggregates its inputs,
+not itself.
+
+
 ### **Coding Challenge Tasks for the Interviewee**
 
 The following tasks must be completed to enhance the backend system:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5979,6 +5979,7 @@
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
       "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,9 @@
         "@types/js-yaml": "^4.0.9",
         "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^22.10.1",
+        "@types/supertest": "^7.2.0",
         "nodemon": "^3.1.7",
+        "supertest": "^7.2.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.2",
         "vitest": "^4.1.5"
@@ -233,6 +235,19 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
@@ -265,6 +280,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2530,6 +2555,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-voronoi": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
@@ -2599,6 +2631,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -2645,6 +2684,30 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2913,6 +2976,13 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2922,6 +2992,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3099,33 +3176,33 @@
         "node": ">= 10"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.0.tgz",
-      "integrity": "sha512-CCKAP2tkPau7D3GE8+V8R6sQubA9R5foIzGp+85EXCVSCivuxBNAWqcpn72PKYiIcqoViv/kcUDpaEIMBVi1lQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -3286,10 +3363,33 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3350,6 +3450,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -3423,20 +3530,14 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -3469,6 +3570,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -3490,11 +3602,12 @@
       }
     },
     "node_modules/dunder-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
-      "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
         "gopd": "^1.2.0"
       },
@@ -3605,6 +3718,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3704,6 +3845,13 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -3762,6 +3910,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -3881,24 +4064,40 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.5.tgz",
-      "integrity": "sha512-Y4+pKa7XeRUPWFNvOOYHkRYrfzW07oraURSvjDmRVOJ748OrVmeXtpE4+GCEHncjCjkTxPNRt8kEbxDhsn6VTg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "dunder-proto": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/github-from-package": {
@@ -3963,21 +4162,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4744,6 +4948,15 @@
         "node": ">= 18"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -5204,9 +5417,10 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5751,22 +5965,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -5804,14 +6002,69 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6101,6 +6354,106 @@
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/node": "^22.10.1",
     "nodemon": "^3.1.7",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "@types/js-yaml": "^4.0.9",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^22.10.1",
+    "@types/supertest": "^7.2.0",
     "nodemon": "^3.1.7",
+    "supertest": "^7.2.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.2",
     "vitest": "^4.1.5"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import express from "express";
 import analysisRoutes from "./routes/analysisRoutes";
+import workflowRoutes from "./routes/workflowRoutes";
 import defaultRoute from "./routes/defaultRoute";
 import { taskWorker } from "./workers/taskWorker";
 import { AppDataSource } from "./data-source"; // Import the DataSource instance
@@ -8,6 +9,7 @@ import { AppDataSource } from "./data-source"; // Import the DataSource instance
 const app = express();
 app.use(express.json());
 app.use("/analysis", analysisRoutes);
+app.use("/workflow", workflowRoutes);
 app.use("/", defaultRoute);
 
 AppDataSource.initialize()

--- a/src/jobs/DataAnalysisJob.ts
+++ b/src/jobs/DataAnalysisJob.ts
@@ -1,11 +1,11 @@
-import { Job } from './Job';
+import { Job, JobContext } from './Job';
 import { Task } from '../models/Task';
 import booleanWithin from '@turf/boolean-within';
 import { Feature, Polygon } from 'geojson';
 import countryMapping from '../data/world_data.json';
 
 export class DataAnalysisJob implements Job {
-    async run(task: Task): Promise<string> {
+    async run(task: Task, _context?: JobContext): Promise<string> {
         console.log(`Running data analysis for task ${task.taskId}...`);
 
         const inputGeometry: Feature<Polygon> = JSON.parse(task.geoJson);

--- a/src/jobs/EmailNotificationJob.ts
+++ b/src/jobs/EmailNotificationJob.ts
@@ -1,8 +1,8 @@
-import { Job } from './Job';
+import { Job, JobContext } from './Job';
 import { Task } from '../models/Task';
 
 export class EmailNotificationJob implements Job {
-    async run(task: Task): Promise<void> {
+    async run(task: Task, _context?: JobContext): Promise<void> {
         console.log(`Sending email notification for task ${task.taskId}...`);
         // Perform notification work
         await new Promise(resolve => setTimeout(resolve, 500));

--- a/src/jobs/Job.ts
+++ b/src/jobs/Job.ts
@@ -1,7 +1,15 @@
 import {Task} from "../models/Task";
 
+export interface JobDependency {
+    stepNumber: number;
+    taskId: string;
+    taskType: string;
+    output: unknown;
+}
+
 export interface JobContext {
     dependencyOutputs: Record<number, unknown>;
+    dependencies?: JobDependency[];
 }
 
 export interface Job {

--- a/src/jobs/Job.ts
+++ b/src/jobs/Job.ts
@@ -1,6 +1,9 @@
 import {Task} from "../models/Task";
 
+export interface JobContext {
+    dependencyOutputs: Record<number, unknown>;
+}
 
 export interface Job {
-    run(task: Task): Promise<any>;
+    run(task: Task, context?: JobContext): Promise<any>;
 }

--- a/src/jobs/JobFactory.ts
+++ b/src/jobs/JobFactory.ts
@@ -2,11 +2,13 @@ import { Job } from './Job';
 import { DataAnalysisJob } from './DataAnalysisJob';
 import { EmailNotificationJob } from './EmailNotificationJob';
 import { PolygonAreaJob } from './PolygonAreaJob';
+import { ReportGenerationJob } from './ReportGenerationJob';
 
 const jobMap: Record<string, () => Job> = {
     'analysis': () => new DataAnalysisJob(),
     'notification': () => new EmailNotificationJob(),
     'polygonArea': () => new PolygonAreaJob(),
+    'reportGeneration': () => new ReportGenerationJob(),
 };
 
 export function getJobForTaskType(taskType: string): Job {

--- a/src/jobs/JobFactory.ts
+++ b/src/jobs/JobFactory.ts
@@ -1,10 +1,12 @@
 import { Job } from './Job';
 import { DataAnalysisJob } from './DataAnalysisJob';
 import { EmailNotificationJob } from './EmailNotificationJob';
+import { PolygonAreaJob } from './PolygonAreaJob';
 
 const jobMap: Record<string, () => Job> = {
     'analysis': () => new DataAnalysisJob(),
     'notification': () => new EmailNotificationJob(),
+    'polygonArea': () => new PolygonAreaJob(),
 };
 
 export function getJobForTaskType(taskType: string): Job {

--- a/src/jobs/PolygonAreaJob.ts
+++ b/src/jobs/PolygonAreaJob.ts
@@ -1,0 +1,24 @@
+import area from '@turf/area';
+import { Job } from './Job';
+import { Task } from '../models/Task';
+
+export class PolygonAreaJob implements Job {
+    async run(task: Task): Promise<number> {
+        let parsed: any;
+        try {
+            parsed = JSON.parse(task.geoJson);
+        } catch (err: any) {
+            throw new Error(`Invalid GeoJSON: ${err.message}`);
+        }
+
+        const geometryType =
+            parsed?.type === 'Feature' ? parsed?.geometry?.type : parsed?.type;
+        if (geometryType !== 'Polygon' && geometryType !== 'MultiPolygon') {
+            throw new Error(
+                `Invalid GeoJSON: expected Polygon or MultiPolygon, got ${geometryType ?? 'unknown'}`,
+            );
+        }
+
+        return area(parsed);
+    }
+}

--- a/src/jobs/PolygonAreaJob.ts
+++ b/src/jobs/PolygonAreaJob.ts
@@ -1,9 +1,9 @@
 import area from '@turf/area';
-import { Job } from './Job';
+import { Job, JobContext } from './Job';
 import { Task } from '../models/Task';
 
 export class PolygonAreaJob implements Job {
-    async run(task: Task): Promise<number> {
+    async run(task: Task, _context?: JobContext): Promise<number> {
         let parsed: any;
         try {
             parsed = JSON.parse(task.geoJson);

--- a/src/jobs/ReportGenerationJob.ts
+++ b/src/jobs/ReportGenerationJob.ts
@@ -1,0 +1,45 @@
+import { Job, JobContext, JobDependency } from './Job';
+import { Task } from '../models/Task';
+
+export interface ReportTaskEntry {
+    taskId: string;
+    type: string;
+    output: unknown;
+}
+
+export interface ReportOutput {
+    workflowId: string;
+    tasks: ReportTaskEntry[];
+    finalReport: string;
+}
+
+export class ReportGenerationJob implements Job {
+    async run(task: Task, context?: JobContext): Promise<ReportOutput> {
+        const workflowId = task.workflow?.workflowId ?? '';
+        const deps: JobDependency[] = context?.dependencies ?? [];
+
+        const tasks: ReportTaskEntry[] = deps
+            .slice()
+            .sort((a, b) => a.stepNumber - b.stepNumber)
+            .map(d => ({
+                taskId: d.taskId,
+                type: d.taskType,
+                output: d.output,
+            }));
+
+        const summaries = tasks.map(t => {
+            const outStr =
+                t.output === null || t.output === undefined
+                    ? 'no output'
+                    : typeof t.output === 'string'
+                        ? t.output
+                        : JSON.stringify(t.output);
+            return `${t.type} (${t.taskId}): ${outStr}`;
+        });
+        const finalReport = summaries.length > 0
+            ? `Aggregated ${summaries.length} task${summaries.length === 1 ? '' : 's'}: ${summaries.join('; ')}`
+            : 'Aggregated 0 tasks';
+
+        return { workflowId, tasks, finalReport };
+    }
+}

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -13,11 +13,14 @@ export class Task {
     @Column('text')
     geoJson!: string;
 
-    @Column()
+    @Column({ type: 'varchar' })
     status!: TaskStatus;
 
     @Column({ nullable: true, type: 'text' })
     progress?: string | null;
+
+    @Column({ nullable: true, type: 'text' })
+    output?: string | null;
 
     @Column({ nullable: true })
     resultId?: string;

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -31,6 +31,9 @@ export class Task {
     @Column({ default: 1 })
     stepNumber!: number;
 
+    @Column({ nullable: true, type: 'text' })
+    dependency?: string | null;
+
     @ManyToOne(() => Workflow, workflow => workflow.tasks)
     workflow!: Workflow;
 }

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -22,6 +22,9 @@ export class Task {
     @Column({ nullable: true, type: 'text' })
     output?: string | null;
 
+    @Column({ nullable: true, type: 'text' })
+    error?: string | null;
+
     @Column({ nullable: true })
     resultId?: string;
 

--- a/src/models/Workflow.ts
+++ b/src/models/Workflow.ts
@@ -13,6 +13,9 @@ export class Workflow {
     @Column({ type: 'varchar', default: WorkflowStatus.Initial })
     status!: WorkflowStatus;
 
+    @Column({ nullable: true, type: 'text' })
+    finalResult?: string | null;
+
     @OneToMany(() => Task, task => task.workflow)
     tasks!: Task[];
 }

--- a/src/models/Workflow.ts
+++ b/src/models/Workflow.ts
@@ -10,7 +10,7 @@ export class Workflow {
     @Column()
     clientId!: string;
 
-    @Column({ default: WorkflowStatus.Initial })
+    @Column({ type: 'varchar', default: WorkflowStatus.Initial })
     status!: WorkflowStatus;
 
     @OneToMany(() => Task, task => task.workflow)

--- a/src/routes/workflowRoutes.ts
+++ b/src/routes/workflowRoutes.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+import { DataSource } from 'typeorm';
+import { AppDataSource } from '../data-source';
+import { Workflow } from '../models/Workflow';
+import { workflowSummary } from '../workflows/workflowSummary';
+import { WorkflowStatus } from './../workflows/WorkflowFactory';
+
+export function createWorkflowRouter(dataSource: DataSource): Router {
+    const router = Router();
+    const workflowRepository = dataSource.getRepository(Workflow);
+
+    router.get('/:id/status', async (req, res) => {
+        const workflow = await workflowRepository.findOne({
+            where: { workflowId: req.params.id },
+            relations: ['tasks'],
+        });
+
+        if (!workflow) {
+            res.status(404).json({ message: 'Workflow not found' });
+            return;
+        }
+
+        const summary = workflowSummary(workflow, {
+            includeTasks: req.query.includeTasks === 'true',
+        });
+
+        res.status(200).json(summary);
+    });
+
+    router.get('/:id/results', async (req, res) => {
+        const workflow = await workflowRepository.findOneBy({ workflowId: req.params.id });
+
+        if (!workflow) {
+            res.status(404).json({ message: 'Workflow not found' });
+            return;
+        }
+
+        const isTerminal =
+            workflow.status === WorkflowStatus.Completed ||
+            workflow.status === WorkflowStatus.Failed;
+
+        if (!isTerminal) {
+            res.status(400).json({
+                message: `Workflow is not in a terminal state (current status: ${workflow.status})`,
+            });
+            return;
+        }
+
+        const parsed = JSON.parse(workflow.finalResult ?? 'null');
+        res.status(200).json(parsed);
+    });
+
+    return router;
+}
+
+const defaultRouter = createWorkflowRouter(AppDataSource);
+export default defaultRouter;

--- a/src/workers/reconciliation.ts
+++ b/src/workers/reconciliation.ts
@@ -1,0 +1,43 @@
+import { DataSource } from 'typeorm';
+import { Task } from '../models/Task';
+import { TaskStatus } from './taskRunner';
+
+export async function reconcileTasks(
+    dataSource: DataSource,
+): Promise<{ reset: number; promoted: number }> {
+    const taskRepository = dataSource.getRepository(Task);
+
+    const stranded = await taskRepository.find({ where: { status: TaskStatus.InProgress } });
+    for (const task of stranded) {
+        task.status = TaskStatus.Queued;
+        task.progress = null;
+        await taskRepository.save(task);
+    }
+
+    const waiting = await taskRepository.find({
+        where: { status: TaskStatus.Waiting },
+        relations: ['workflow'],
+    });
+    let promoted = 0;
+    for (const task of waiting) {
+        const deps: number[] = task.dependency ? JSON.parse(task.dependency) : [];
+        if (deps.length === 0) continue;
+        const workflowId = task.workflow?.workflowId;
+        if (!workflowId) continue;
+        const siblings = await taskRepository.find({
+            where: { workflow: { workflowId } },
+            relations: ['workflow'],
+        });
+        const completedSteps = new Set<number>();
+        for (const sibling of siblings) {
+            if (sibling.status === TaskStatus.Completed) completedSteps.add(sibling.stepNumber);
+        }
+        if (deps.every(d => completedSteps.has(d))) {
+            task.status = TaskStatus.Queued;
+            await taskRepository.save(task);
+            promoted++;
+        }
+    }
+
+    return { reset: stranded.length, promoted };
+}

--- a/src/workers/taskRunner.ts
+++ b/src/workers/taskRunner.ts
@@ -1,10 +1,11 @@
-import { In, Repository } from 'typeorm';
+import { EntityManager, In, Repository } from 'typeorm';
 import { Task } from '../models/Task';
 import { getJobForTaskType } from '../jobs/JobFactory';
 import {WorkflowStatus} from "../workflows/WorkflowFactory";
 import {Workflow} from "../models/Workflow";
 import {Result} from "../models/Result";
 import {JobContext, JobDependency} from "../jobs/Job";
+import {workflowSummary} from "../workflows/workflowSummary";
 
 export enum TaskStatus {
     Waiting = 'waiting',
@@ -72,6 +73,8 @@ export class TaskRunner {
                         }
                     }
                 }
+
+                await this.updateWorkflowStatus(tx, task.workflow.workflowId);
             });
 
         } catch (error: any) {
@@ -123,17 +126,16 @@ export class TaskRunner {
                         queue.push(candidate.stepNumber);
                     }
                 }
+
+                await this.updateWorkflowStatus(tx, task.workflow.workflowId);
             });
 
-            await this.updateWorkflowStatus(task.workflow.workflowId);
             throw error;
         }
-
-        await this.updateWorkflowStatus(task.workflow.workflowId);
     }
 
-    private async updateWorkflowStatus(workflowId: string): Promise<void> {
-        const workflowRepository = this.taskRepository.manager.getRepository(Workflow);
+    private async updateWorkflowStatus(tx: EntityManager, workflowId: string): Promise<void> {
+        const workflowRepository = tx.getRepository(Workflow);
         const currentWorkflow = await workflowRepository.findOne({ where: { workflowId }, relations: ['tasks'] });
 
         if (currentWorkflow) {
@@ -146,6 +148,15 @@ export class TaskRunner {
                 currentWorkflow.status = WorkflowStatus.Completed;
             } else {
                 currentWorkflow.status = WorkflowStatus.InProgress;
+            }
+
+            const isTerminal =
+                currentWorkflow.status === WorkflowStatus.Completed ||
+                currentWorkflow.status === WorkflowStatus.Failed;
+            if (isTerminal && !currentWorkflow.finalResult) {
+                currentWorkflow.finalResult = JSON.stringify(
+                    workflowSummary(currentWorkflow, { includeTasks: true }),
+                );
             }
 
             await workflowRepository.save(currentWorkflow);

--- a/src/workers/taskRunner.ts
+++ b/src/workers/taskRunner.ts
@@ -6,6 +6,7 @@ import {Workflow} from "../models/Workflow";
 import {Result} from "../models/Result";
 
 export enum TaskStatus {
+    Waiting = 'waiting',
     Queued = 'queued',
     InProgress = 'in_progress',
     Completed = 'completed',
@@ -30,18 +31,45 @@ export class TaskRunner {
 
         try {
             console.log(`Starting job ${task.taskType} for task ${task.taskId}...`);
-            const resultRepository = this.taskRepository.manager.getRepository(Result);
             const taskResult = await job.run(task);
             console.log(`Job ${task.taskType} for task ${task.taskId} completed successfully.`);
-            const result = new Result();
-            result.taskId = task.taskId!;
-            result.data = JSON.stringify(taskResult || {});
-            await resultRepository.save(result);
-            task.resultId = result.resultId!;
-            task.status = TaskStatus.Completed;
-            task.progress = null;
-            task.output = JSON.stringify(taskResult ?? null);
-            await this.taskRepository.save(task);
+
+            await this.taskRepository.manager.transaction(async (tx) => {
+                const txTaskRepo = tx.getRepository(Task);
+                const txResultRepo = tx.getRepository(Result);
+
+                const result = new Result();
+                result.taskId = task.taskId!;
+                result.data = JSON.stringify(taskResult || {});
+                await txResultRepo.save(result);
+                task.resultId = result.resultId!;
+                task.status = TaskStatus.Completed;
+                task.progress = null;
+                task.output = JSON.stringify(taskResult ?? null);
+                await txTaskRepo.save(task);
+
+                const siblings = await txTaskRepo.find({
+                    where: { workflow: { workflowId: task.workflow.workflowId }, status: TaskStatus.Waiting },
+                    relations: ['workflow'],
+                });
+                if (siblings.length > 0) {
+                    const completedSteps = new Set<number>();
+                    const allTasks = await txTaskRepo.find({
+                        where: { workflow: { workflowId: task.workflow.workflowId } },
+                        relations: ['workflow'],
+                    });
+                    for (const t of allTasks) {
+                        if (t.status === TaskStatus.Completed) completedSteps.add(t.stepNumber);
+                    }
+                    for (const sibling of siblings) {
+                        const deps: number[] = sibling.dependency ? JSON.parse(sibling.dependency) : [];
+                        if (deps.length > 0 && deps.every(d => completedSteps.has(d))) {
+                            sibling.status = TaskStatus.Queued;
+                            await txTaskRepo.save(sibling);
+                        }
+                    }
+                }
+            });
 
         } catch (error: any) {
             console.error(`Error running job ${task.taskType} for task ${task.taskId}:`, error);

--- a/src/workers/taskRunner.ts
+++ b/src/workers/taskRunner.ts
@@ -1,9 +1,10 @@
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Task } from '../models/Task';
 import { getJobForTaskType } from '../jobs/JobFactory';
 import {WorkflowStatus} from "../workflows/WorkflowFactory";
 import {Workflow} from "../models/Workflow";
 import {Result} from "../models/Result";
+import {JobContext, JobDependency} from "../jobs/Job";
 
 export enum TaskStatus {
     Waiting = 'waiting',
@@ -29,9 +30,11 @@ export class TaskRunner {
         await this.taskRepository.save(task);
         const job = getJobForTaskType(task.taskType);
 
+        const context = await this.buildJobContext(task);
+
         try {
             console.log(`Starting job ${task.taskType} for task ${task.taskId}...`);
-            const taskResult = await job.run(task);
+            const taskResult = await job.run(task, context);
             console.log(`Job ${task.taskType} for task ${task.taskId} completed successfully.`);
 
             await this.taskRepository.manager.transaction(async (tx) => {
@@ -98,5 +101,58 @@ export class TaskRunner {
 
             await workflowRepository.save(currentWorkflow);
         }
+    }
+
+    private async buildJobContext(task: Task): Promise<JobContext | undefined> {
+        if (!task.dependency) {
+            return undefined;
+        }
+        let deps: number[];
+        try {
+            deps = JSON.parse(task.dependency);
+        } catch {
+            return undefined;
+        }
+        if (!Array.isArray(deps) || deps.length === 0) {
+            return undefined;
+        }
+
+        const workflowId = task.workflow?.workflowId;
+        if (!workflowId) {
+            return { dependencyOutputs: {}, dependencies: [] };
+        }
+
+        const parents = await this.taskRepository.find({
+            where: {
+                workflow: { workflowId },
+                stepNumber: In(deps),
+            },
+            relations: ['workflow'],
+        });
+
+        const dependencyOutputs: Record<number, unknown> = {};
+        const dependencies: JobDependency[] = [];
+        for (const step of deps) {
+            dependencyOutputs[step] = null;
+        }
+        for (const parent of parents) {
+            let parsed: unknown = null;
+            if (parent.output !== null && parent.output !== undefined) {
+                try {
+                    parsed = JSON.parse(parent.output);
+                } catch {
+                    parsed = parent.output;
+                }
+            }
+            dependencyOutputs[parent.stepNumber] = parsed;
+            dependencies.push({
+                stepNumber: parent.stepNumber,
+                taskId: parent.taskId,
+                taskType: parent.taskType,
+                output: parsed,
+            });
+        }
+        dependencies.sort((a, b) => a.stepNumber - b.stepNumber);
+        return { dependencyOutputs, dependencies };
     }
 }

--- a/src/workers/taskRunner.ts
+++ b/src/workers/taskRunner.ts
@@ -77,15 +77,64 @@ export class TaskRunner {
         } catch (error: any) {
             console.error(`Error running job ${task.taskType} for task ${task.taskId}:`, error);
 
-            task.status = TaskStatus.Failed;
-            task.progress = null;
-            await this.taskRepository.save(task);
+            await this.taskRepository.manager.transaction(async (tx) => {
+                const txTaskRepo = tx.getRepository(Task);
 
+                task.status = TaskStatus.Failed;
+                task.progress = null;
+                task.error = error?.message ?? String(error);
+                await txTaskRepo.save(task);
+
+                const allTasks = await txTaskRepo.find({
+                    where: { workflow: { workflowId: task.workflow.workflowId } },
+                    relations: ['workflow'],
+                });
+
+                const failedSteps = new Set<number>();
+                for (const t of allTasks) {
+                    if (t.status === TaskStatus.Failed) failedSteps.add(t.stepNumber);
+                }
+
+                const queue: number[] = [task.stepNumber];
+                const cascaded = new Set<number>();
+                while (queue.length > 0) {
+                    const parentStep = queue.shift()!;
+                    for (const candidate of allTasks) {
+                        if (candidate.stepNumber === parentStep) continue;
+                        if (cascaded.has(candidate.stepNumber)) continue;
+                        if (candidate.taskId === task.taskId) continue;
+                        if (candidate.status === TaskStatus.Completed || candidate.status === TaskStatus.Failed) continue;
+                        const deps: number[] = candidate.dependency
+                            ? JSON.parse(candidate.dependency)
+                            : [];
+                        if (!deps.includes(parentStep)) continue;
+
+                        const failedDepSteps = deps
+                            .filter(d => failedSteps.has(d) || d === task.stepNumber || cascaded.has(d))
+                            .sort((a, b) => a - b);
+                        const reasonStep = failedDepSteps[0] ?? parentStep;
+
+                        candidate.status = TaskStatus.Failed;
+                        candidate.progress = null;
+                        candidate.error = `Skipped: dependency ${reasonStep} failed`;
+                        await txTaskRepo.save(candidate);
+
+                        cascaded.add(candidate.stepNumber);
+                        queue.push(candidate.stepNumber);
+                    }
+                }
+            });
+
+            await this.updateWorkflowStatus(task.workflow.workflowId);
             throw error;
         }
 
+        await this.updateWorkflowStatus(task.workflow.workflowId);
+    }
+
+    private async updateWorkflowStatus(workflowId: string): Promise<void> {
         const workflowRepository = this.taskRepository.manager.getRepository(Workflow);
-        const currentWorkflow = await workflowRepository.findOne({ where: { workflowId: task.workflow.workflowId }, relations: ['tasks'] });
+        const currentWorkflow = await workflowRepository.findOne({ where: { workflowId }, relations: ['tasks'] });
 
         if (currentWorkflow) {
             const allCompleted = currentWorkflow.tasks.every(t => t.status === TaskStatus.Completed);

--- a/src/workers/taskRunner.ts
+++ b/src/workers/taskRunner.ts
@@ -40,6 +40,7 @@ export class TaskRunner {
             task.resultId = result.resultId!;
             task.status = TaskStatus.Completed;
             task.progress = null;
+            task.output = JSON.stringify(taskResult ?? null);
             await this.taskRepository.save(task);
 
         } catch (error: any) {

--- a/src/workers/taskWorker.ts
+++ b/src/workers/taskWorker.ts
@@ -1,10 +1,13 @@
 import {AppDataSource} from '../data-source';
 import {Task} from '../models/Task';
 import {TaskRunner, TaskStatus} from './taskRunner';
+import {reconcileTasks} from './reconciliation';
 
 export async function taskWorker() {
     const taskRepository = AppDataSource.getRepository(Task);
     const taskRunner = new TaskRunner(taskRepository);
+
+    await reconcileTasks(AppDataSource);
 
     while (true) {
         const task = await taskRepository.findOne({

--- a/src/workflows/WorkflowFactory.ts
+++ b/src/workflows/WorkflowFactory.ts
@@ -15,6 +15,7 @@ export enum WorkflowStatus {
 interface WorkflowStep {
     taskType: string;
     stepNumber: number;
+    dependsOn?: number[];
 }
 
 interface WorkflowDefinition {
@@ -48,10 +49,16 @@ export class WorkflowFactory {
             const task = new Task();
             task.clientId = clientId;
             task.geoJson = geoJson;
-            task.status = TaskStatus.Queued;
             task.taskType = step.taskType;
             task.stepNumber = step.stepNumber;
             task.workflow = savedWorkflow;
+            if (step.dependsOn && step.dependsOn.length > 0) {
+                task.dependency = JSON.stringify(step.dependsOn);
+                task.status = TaskStatus.Waiting;
+            } else {
+                task.dependency = null;
+                task.status = TaskStatus.Queued;
+            }
             return task;
         });
 

--- a/src/workflows/example_workflow.yml
+++ b/src/workflows/example_workflow.yml
@@ -1,6 +1,9 @@
 name: "example_workflow"
 steps:
-  - taskType: "analysis"
+  - taskType: "polygonArea"
     stepNumber: 1
-  - taskType: "notification"
+  - taskType: "analysis"
     stepNumber: 2
+  - taskType: "reportGeneration"
+    stepNumber: 3
+    dependsOn: [1, 2]

--- a/src/workflows/workflowSummary.ts
+++ b/src/workflows/workflowSummary.ts
@@ -1,0 +1,114 @@
+export interface WorkflowSummaryOptions {
+  includeTasks: boolean;
+}
+
+export interface SummarisableTask {
+  taskId: string;
+  stepNumber: number;
+  taskType: string;
+  status: string;
+  output?: string | null;
+  progress?: string | null;
+}
+
+export interface SummarisableWorkflow {
+  workflowId: string;
+  status: string;
+  tasks: SummarisableTask[];
+}
+
+export interface CompletedTaskSummary {
+  stepNumber: number;
+  taskId: string;
+  taskType: string;
+  status: "completed";
+  output: unknown;
+}
+
+export interface FailedTaskSummary {
+  stepNumber: number;
+  taskId: string;
+  taskType: string;
+  status: "failed";
+  error: string;
+}
+
+export type NonTerminalStatus = "waiting" | "queued" | "in_progress";
+
+export interface NonTerminalTaskSummary {
+  stepNumber: number;
+  taskId: string;
+  taskType: string;
+  status: NonTerminalStatus;
+  progress?: string;
+}
+
+export type TaskSummary =
+  | CompletedTaskSummary
+  | FailedTaskSummary
+  | NonTerminalTaskSummary;
+
+export interface WorkflowSummary {
+  workflowId: string;
+  status: string;
+  completedTasks: number;
+  totalTasks: number;
+  tasks?: TaskSummary[];
+}
+
+function summariseTask(task: SummarisableTask): TaskSummary {
+  const base = {
+    stepNumber: task.stepNumber,
+    taskId: task.taskId,
+    taskType: task.taskType,
+  };
+
+  if (task.status === "completed") {
+    return {
+      ...base,
+      status: "completed",
+      output: JSON.parse(task.output ?? "null"),
+    };
+  }
+
+  if (task.status === "failed") {
+    return {
+      ...base,
+      status: "failed",
+      error: task.progress ?? "",
+    };
+  }
+
+  const nonTerminal: NonTerminalTaskSummary = {
+    ...base,
+    status: task.status as NonTerminalStatus,
+  };
+  if (task.progress != null) {
+    nonTerminal.progress = task.progress;
+  }
+  return nonTerminal;
+}
+
+export function workflowSummary(
+  workflow: SummarisableWorkflow,
+  options: WorkflowSummaryOptions,
+): WorkflowSummary {
+  const completedTasks = workflow.tasks.filter(
+    t => t.status === "completed",
+  ).length;
+
+  const summary: WorkflowSummary = {
+    workflowId: workflow.workflowId,
+    status: workflow.status,
+    completedTasks,
+    totalTasks: workflow.tasks.length,
+  };
+
+  if (options.includeTasks) {
+    summary.tasks = [...workflow.tasks]
+      .sort((a, b) => a.stepNumber - b.stepNumber)
+      .map(summariseTask);
+  }
+
+  return summary;
+}

--- a/src/workflows/workflowSummary.ts
+++ b/src/workflows/workflowSummary.ts
@@ -9,6 +9,7 @@ export interface SummarisableTask {
   status: string;
   output?: string | null;
   progress?: string | null;
+  error?: string | null;
 }
 
 export interface SummarisableWorkflow {
@@ -75,7 +76,7 @@ function summariseTask(task: SummarisableTask): TaskSummary {
     return {
       ...base,
       status: "failed",
-      error: task.progress ?? "",
+      error: task.error ?? task.progress ?? "",
     };
   }
 

--- a/tests/integration/fanInWorkflow.test.ts
+++ b/tests/integration/fanInWorkflow.test.ts
@@ -1,0 +1,152 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as path from "path";
+import express from "express";
+import request from "supertest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { WorkflowFactory, WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
+import { createWorkflowRouter } from "../../src/routes/workflowRoutes";
+
+describe("fan-in workflow end-to-end (polygonArea + analysis -> reportGeneration)", () => {
+  let dataSource: DataSource;
+
+  const geoJson = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [
+        [-63.624885020050996, -10.311050368263523],
+        [-63.624885020050996, -10.367865108370523],
+        [-63.61278302732815, -10.367865108370523],
+        [-63.61278302732815, -10.311050368263523],
+        [-63.624885020050996, -10.311050368263523],
+      ],
+    ],
+  });
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: "sqlite",
+      database: ":memory:",
+      dropSchema: true,
+      synchronize: true,
+      entities: [Task, Result, Workflow],
+    });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  async function drainQueuedTasks(): Promise<void> {
+    const taskRepository = dataSource.getRepository(Task);
+    const runner = new TaskRunner(taskRepository);
+
+    // Inlined taskWorker loop (no setTimeout) - run until no Queued tasks remain.
+    // Safety bound prevents infinite loops if a bug leaves tasks queued.
+    for (let i = 0; i < 50; i++) {
+      const next = await taskRepository.findOne({
+        where: { status: TaskStatus.Queued },
+        relations: ["workflow"],
+      });
+      if (!next) return;
+      try {
+        await runner.run(next);
+      } catch {
+        // TaskRunner has already marked the task failed; keep draining.
+      }
+    }
+    throw new Error("drainQueuedTasks: exceeded max iterations");
+  }
+
+  it("runs all three tasks to completion and exposes results via HTTP endpoints", async () => {
+    const yamlPath = path.join(__dirname, "../../src/workflows/example_workflow.yml");
+    const factory = new WorkflowFactory(dataSource);
+    const workflow = await factory.createWorkflowFromYAML(yamlPath, "demo", geoJson);
+
+    await drainQueuedTasks();
+
+    const taskRepo = dataSource.getRepository(Task);
+    const workflowRepo = dataSource.getRepository(Workflow);
+
+    const tasks = await taskRepo.find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+    });
+    expect(tasks).toHaveLength(3);
+    for (const t of tasks) {
+      expect(t.status).toBe(TaskStatus.Completed);
+    }
+
+    const reloaded = await workflowRepo.findOne({
+      where: { workflowId: workflow.workflowId },
+      relations: ["tasks"],
+    });
+    expect(reloaded?.status).toBe(WorkflowStatus.Completed);
+    expect(reloaded?.finalResult).toBeTruthy();
+
+    const finalResult = JSON.parse(reloaded!.finalResult!);
+    expect(finalResult.workflowId).toBe(workflow.workflowId);
+    expect(finalResult.status).toBe(WorkflowStatus.Completed);
+    expect(finalResult.totalTasks).toBe(3);
+    expect(finalResult.completedTasks).toBe(3);
+    expect(Array.isArray(finalResult.tasks)).toBe(true);
+    expect(finalResult.tasks).toHaveLength(3);
+    expect(finalResult.tasks.map((t: any) => t.stepNumber)).toEqual([1, 2, 3]);
+    expect(finalResult.tasks.map((t: any) => t.taskType)).toEqual([
+      "polygonArea",
+      "analysis",
+      "reportGeneration",
+    ]);
+    for (const t of finalResult.tasks) {
+      expect(t.status).toBe("completed");
+      expect(t.output).toBeDefined();
+    }
+
+    const reportEntry = finalResult.tasks.find((t: any) => t.taskType === "reportGeneration");
+    expect(reportEntry.output).toMatchObject({
+      workflowId: workflow.workflowId,
+      finalReport: expect.any(String),
+    });
+    expect(Array.isArray(reportEntry.output.tasks)).toBe(true);
+    expect(reportEntry.output.tasks).toHaveLength(2);
+    expect(reportEntry.output.tasks.map((d: any) => d.type).sort()).toEqual([
+      "analysis",
+      "polygonArea",
+    ]);
+
+    const app = express();
+    app.use(express.json());
+    app.use("/workflow", createWorkflowRouter(dataSource));
+
+    const statusRes = await request(app).get(`/workflow/${workflow.workflowId}/status`);
+    expect(statusRes.status).toBe(200);
+    expect(statusRes.body).toMatchObject({
+      workflowId: workflow.workflowId,
+      status: WorkflowStatus.Completed,
+      completedTasks: 3,
+      totalTasks: 3,
+    });
+
+    const statusWithTasksRes = await request(app)
+      .get(`/workflow/${workflow.workflowId}/status`)
+      .query({ includeTasks: "true" });
+    expect(statusWithTasksRes.status).toBe(200);
+    expect(statusWithTasksRes.body.tasks.map((t: any) => t.stepNumber)).toEqual([1, 2, 3]);
+    expect(statusWithTasksRes.body.tasks.map((t: any) => t.taskType)).toEqual([
+      "polygonArea",
+      "analysis",
+      "reportGeneration",
+    ]);
+
+    const resultsRes = await request(app).get(`/workflow/${workflow.workflowId}/results`);
+    expect(resultsRes.status).toBe(200);
+    expect(resultsRes.body).toEqual(finalResult);
+  });
+});

--- a/tests/jobs/JobFactory.test.ts
+++ b/tests/jobs/JobFactory.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { getJobForTaskType } from "../../src/jobs/JobFactory";
+import { ReportGenerationJob } from "../../src/jobs/ReportGenerationJob";
 
 describe("test harness smoke test", () => {
   it("imports a source module and exposes getJobForTaskType", () => {
     expect(typeof getJobForTaskType).toBe("function");
+  });
+
+  it("maps 'reportGeneration' to ReportGenerationJob", () => {
+    const job = getJobForTaskType("reportGeneration");
+    expect(job).toBeInstanceOf(ReportGenerationJob);
   });
 });

--- a/tests/jobs/PolygonAreaJob.test.ts
+++ b/tests/jobs/PolygonAreaJob.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { PolygonAreaJob } from "../../src/jobs/PolygonAreaJob";
+import { Task } from "../../src/models/Task";
+
+function makeTask(geoJson: unknown): Task {
+  const t = new Task();
+  t.geoJson = typeof geoJson === "string" ? geoJson : JSON.stringify(geoJson);
+  t.taskType = "polygonArea";
+  return t;
+}
+
+describe("PolygonAreaJob", () => {
+  it("returns the geodesic area in square metres for a Feature<Polygon>", async () => {
+    const job = new PolygonAreaJob();
+    const feature = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [125, -15],
+            [113, -22],
+            [154, -27],
+            [144, -15],
+            [125, -15],
+          ],
+        ],
+      },
+    };
+
+    const area = await job.run(makeTask(feature));
+
+    expect(typeof area).toBe("number");
+    expect(area).toBeGreaterThan(0);
+  });
+
+  it("returns a positive area for a bare Polygon geometry", async () => {
+    const job = new PolygonAreaJob();
+    const polygon = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [125, -15],
+          [113, -22],
+          [154, -27],
+          [144, -15],
+          [125, -15],
+        ],
+      ],
+    };
+
+    const result = await job.run(makeTask(polygon));
+
+    expect(typeof result).toBe("number");
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("returns a positive area for a MultiPolygon geometry", async () => {
+    const job = new PolygonAreaJob();
+    const multi = {
+      type: "MultiPolygon",
+      coordinates: [
+        [
+          [
+            [0, 0],
+            [0, 1],
+            [1, 1],
+            [1, 0],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [10, 10],
+            [10, 11],
+            [11, 11],
+            [11, 10],
+            [10, 10],
+          ],
+        ],
+      ],
+    };
+
+    const result = await job.run(makeTask(multi));
+
+    expect(typeof result).toBe("number");
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("throws a descriptive Error when geoJson is not valid JSON", async () => {
+    const job = new PolygonAreaJob();
+    const task = makeTask("{not json");
+
+    await expect(job.run(task)).rejects.toThrow(/invalid geojson/i);
+  });
+
+  it("throws a descriptive Error for non-polygon geometry (e.g. Point)", async () => {
+    const job = new PolygonAreaJob();
+    const point = { type: "Point", coordinates: [0, 0] };
+
+    await expect(job.run(makeTask(point))).rejects.toThrow(
+      /polygon|multipolygon/i,
+    );
+  });
+
+  it("computes the Readme example polygon area within tolerance", async () => {
+    const job = new PolygonAreaJob();
+    const readmePolygon = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [-63.624885020050996, -10.311050368263523],
+          [-63.624885020050996, -10.367865108370523],
+          [-63.61278302732815, -10.367865108370523],
+          [-63.61278302732815, -10.311050368263523],
+          [-63.624885020050996, -10.311050368263523],
+        ],
+      ],
+    };
+
+    const result = await job.run(makeTask(readmePolygon));
+
+    // Roughly ~1.34 km x ~6.3 km rectangular box ≈ 8.4e6 m²
+    expect(result).toBeGreaterThan(8_000_000);
+    expect(result).toBeLessThan(9_000_000);
+  });
+});

--- a/tests/jobs/ReportGenerationJob.test.ts
+++ b/tests/jobs/ReportGenerationJob.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { ReportGenerationJob } from "../../src/jobs/ReportGenerationJob";
+import { Task } from "../../src/models/Task";
+import { Workflow } from "../../src/models/Workflow";
+import { JobContext } from "../../src/jobs/Job";
+
+function makeReportTask(workflowId: string): Task {
+  const wf = new Workflow();
+  wf.workflowId = workflowId;
+  const t = new Task();
+  t.taskId = "report-task-id";
+  t.taskType = "reportGeneration";
+  t.stepNumber = 99;
+  t.workflow = wf;
+  t.geoJson = "{}";
+  return t;
+}
+
+describe("ReportGenerationJob", () => {
+  it("produces Readme-#2 shape for a single dependency", async () => {
+    const job = new ReportGenerationJob();
+    const task = makeReportTask("wf-1");
+    const context: JobContext = {
+      dependencyOutputs: { 1: 12345.6 },
+      dependencies: [
+        { stepNumber: 1, taskId: "parent-1", taskType: "polygonArea", output: 12345.6 },
+      ],
+    };
+
+    const result = await job.run(task, context);
+
+    expect(result.workflowId).toBe("wf-1");
+    expect(Array.isArray(result.tasks)).toBe(true);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toEqual({
+      taskId: "parent-1",
+      type: "polygonArea",
+      output: 12345.6,
+    });
+    expect(typeof result.finalReport).toBe("string");
+    expect(result.finalReport.length).toBeGreaterThan(0);
+  });
+
+  it("aggregates multiple dependencies (fan-in) into tasks[]", async () => {
+    const job = new ReportGenerationJob();
+    const task = makeReportTask("wf-fanin");
+    const context: JobContext = {
+      dependencyOutputs: { 1: 12345.6, 2: "Brazil" },
+      dependencies: [
+        { stepNumber: 1, taskId: "p-1", taskType: "polygonArea", output: 12345.6 },
+        { stepNumber: 2, taskId: "p-2", taskType: "analysis", output: "Brazil" },
+      ],
+    };
+
+    const result = await job.run(task, context);
+
+    expect(result.workflowId).toBe("wf-fanin");
+    expect(result.tasks).toHaveLength(2);
+    expect(result.tasks).toEqual([
+      { taskId: "p-1", type: "polygonArea", output: 12345.6 },
+      { taskId: "p-2", type: "analysis", output: "Brazil" },
+    ]);
+    expect(typeof result.finalReport).toBe("string");
+  });
+
+  it("surfaces a parent with null output as null in tasks[].output", async () => {
+    const job = new ReportGenerationJob();
+    const task = makeReportTask("wf-null");
+    const context: JobContext = {
+      dependencyOutputs: { 1: null },
+      dependencies: [
+        { stepNumber: 1, taskId: "p-null", taskType: "notification", output: null },
+      ],
+    };
+
+    const result = await job.run(task, context);
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toEqual({
+      taskId: "p-null",
+      type: "notification",
+      output: null,
+    });
+    expect(result.tasks[0].output).toBeNull();
+  });
+});

--- a/tests/routes/workflowRoutes.test.ts
+++ b/tests/routes/workflowRoutes.test.ts
@@ -1,0 +1,185 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskStatus } from "../../src/workers/taskRunner";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { createWorkflowRouter } from "../../src/routes/workflowRoutes";
+
+describe("GET /workflow/:id/status and /workflow/:id/results", () => {
+  let dataSource: DataSource;
+  let app: express.Express;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: "sqlite",
+      database: ":memory:",
+      dropSchema: true,
+      synchronize: true,
+      entities: [Task, Result, Workflow],
+    });
+    await dataSource.initialize();
+
+    app = express();
+    app.use(express.json());
+    app.use("/workflow", createWorkflowRouter(dataSource));
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  async function seedWorkflow(status: WorkflowStatus = WorkflowStatus.Initial): Promise<Workflow> {
+    const workflowRepo = dataSource.getRepository(Workflow);
+    const workflow = new Workflow();
+    workflow.clientId = "client-test";
+    workflow.status = status;
+    return await workflowRepo.save(workflow);
+  }
+
+  function makeTask(
+    workflow: Workflow,
+    stepNumber: number,
+    status: TaskStatus,
+    overrides: Partial<Task> = {},
+  ): Task {
+    const task = new Task();
+    task.clientId = "client-test";
+    task.geoJson = "{}";
+    task.taskType = "polygonArea";
+    task.status = status;
+    task.stepNumber = stepNumber;
+    task.dependency = null;
+    task.workflow = workflow;
+    Object.assign(task, overrides);
+    return task;
+  }
+
+  describe("GET /workflow/:id/status", () => {
+    it("returns 200 with workflow summary (no tasks[] by default)", async () => {
+      const workflow = await seedWorkflow(WorkflowStatus.InProgress);
+      const taskRepo = dataSource.getRepository(Task);
+      await taskRepo.save([
+        makeTask(workflow, 1, TaskStatus.Completed, { output: JSON.stringify({ area: 1 }) }),
+        makeTask(workflow, 2, TaskStatus.Queued),
+      ]);
+
+      const res = await request(app).get(`/workflow/${workflow.workflowId}/status`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        workflowId: workflow.workflowId,
+        status: WorkflowStatus.InProgress,
+        completedTasks: 1,
+        totalTasks: 2,
+      });
+      expect(res.body.tasks).toBeUndefined();
+    });
+
+    it("returns 200 with tasks[] ordered by stepNumber when ?includeTasks=true", async () => {
+      const workflow = await seedWorkflow(WorkflowStatus.InProgress);
+      const taskRepo = dataSource.getRepository(Task);
+      await taskRepo.save([
+        makeTask(workflow, 2, TaskStatus.Queued),
+        makeTask(workflow, 1, TaskStatus.Completed, { output: JSON.stringify({ area: 1 }) }),
+        makeTask(workflow, 3, TaskStatus.Waiting),
+      ]);
+
+      const res = await request(app)
+        .get(`/workflow/${workflow.workflowId}/status`)
+        .query({ includeTasks: "true" });
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.tasks)).toBe(true);
+      expect(res.body.tasks.map((t: any) => t.stepNumber)).toEqual([1, 2, 3]);
+    });
+
+    it("returns 404 for unknown workflow id", async () => {
+      const res = await request(app).get(`/workflow/unknownid/status`);
+      expect(res.status).toBe(404);
+    });
+
+    it("does not count failed tasks as completed", async () => {
+      const workflow = await seedWorkflow(WorkflowStatus.InProgress);
+      const taskRepo = dataSource.getRepository(Task);
+      await taskRepo.save([
+        makeTask(workflow, 1, TaskStatus.Completed, { output: JSON.stringify({ area: 1 }) }),
+        makeTask(workflow, 2, TaskStatus.Failed, { error: "boom" }),
+        makeTask(workflow, 3, TaskStatus.Queued),
+      ]);
+
+      const res = await request(app).get(`/workflow/${workflow.workflowId}/status`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.completedTasks).toBe(1);
+      expect(res.body.totalTasks).toBe(3);
+    });
+  });
+
+  describe("GET /workflow/:id/results", () => {
+    it("returns 200 with parsed finalResult for a completed workflow", async () => {
+      const finalResult = {
+        workflowId: "wfid",
+        status: "completed",
+        completedTasks: 2,
+        totalTasks: 2,
+        tasks: [
+          { stepNumber: 1, taskId: "t1", taskType: "polygonArea", status: "completed", output: { area: 1 } },
+          { stepNumber: 2, taskId: "t2", taskType: "polygonArea", status: "completed", output: { area: 2 } },
+        ],
+      };
+      const workflow = await seedWorkflow(WorkflowStatus.Completed);
+      workflow.finalResult = JSON.stringify(finalResult);
+      await dataSource.getRepository(Workflow).save(workflow);
+
+      const res = await request(app).get(`/workflow/${workflow.workflowId}/results`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(finalResult);
+    });
+
+    it("returns 200 for a failed workflow (terminal includes failed)", async () => {
+      const finalResult = {
+        workflowId: "wfid",
+        status: "failed",
+        completedTasks: 0,
+        totalTasks: 1,
+        tasks: [
+          { stepNumber: 1, taskId: "t1", taskType: "polygonArea", status: "failed", error: "boom" },
+        ],
+      };
+      const workflow = await seedWorkflow(WorkflowStatus.Failed);
+      workflow.finalResult = JSON.stringify(finalResult);
+      await dataSource.getRepository(Workflow).save(workflow);
+
+      const res = await request(app).get(`/workflow/${workflow.workflowId}/results`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(finalResult);
+    });
+
+    it("returns 400 for an in_progress workflow", async () => {
+      const workflow = await seedWorkflow(WorkflowStatus.InProgress);
+      const res = await request(app).get(`/workflow/${workflow.workflowId}/results`);
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty("message");
+    });
+
+    it("returns 400 for an initial workflow", async () => {
+      const workflow = await seedWorkflow(WorkflowStatus.Initial);
+      const res = await request(app).get(`/workflow/${workflow.workflowId}/results`);
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for an unknown workflow id", async () => {
+      const res = await request(app).get(`/workflow/unknownid/results`);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/tests/workers/reconciliation.test.ts
+++ b/tests/workers/reconciliation.test.ts
@@ -1,0 +1,171 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskStatus } from "../../src/workers/taskRunner";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { reconcileTasks } from "../../src/workers/reconciliation";
+
+describe("reconcileTasks startup sweep", () => {
+  let dataSource: DataSource;
+
+  const geoJson = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [
+        [-63.6, -10.3],
+        [-63.6, -10.4],
+        [-63.5, -10.4],
+        [-63.5, -10.3],
+        [-63.6, -10.3],
+      ],
+    ],
+  });
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: "sqlite",
+      database: ":memory:",
+      dropSchema: true,
+      synchronize: true,
+      entities: [Task, Result, Workflow],
+    });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  async function seedWorkflow(): Promise<Workflow> {
+    const workflowRepo = dataSource.getRepository(Workflow);
+    const workflow = new Workflow();
+    workflow.clientId = "client-test";
+    workflow.status = WorkflowStatus.Initial;
+    return await workflowRepo.save(workflow);
+  }
+
+  function makeTask(
+    workflow: Workflow,
+    stepNumber: number,
+    status: TaskStatus,
+    dependency: number[] | null,
+    overrides: Partial<Task> = {},
+  ): Task {
+    const task = new Task();
+    task.clientId = "client-test";
+    task.geoJson = geoJson;
+    task.taskType = "polygonArea";
+    task.status = status;
+    task.stepNumber = stepNumber;
+    task.dependency = dependency ? JSON.stringify(dependency) : null;
+    task.workflow = workflow;
+    Object.assign(task, overrides);
+    return task;
+  }
+
+  it("is a no-op on a fresh database", async () => {
+    const result = await reconcileTasks(dataSource);
+    expect(result).toEqual({ reset: 0, promoted: 0 });
+  });
+
+  it("resets stranded InProgress tasks to Queued and clears progress", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+    const stranded = makeTask(workflow, 1, TaskStatus.InProgress, null, {
+      progress: "working...",
+    });
+    await taskRepo.save(stranded);
+
+    const result = await reconcileTasks(dataSource);
+
+    expect(result).toEqual({ reset: 1, promoted: 0 });
+    const after = await taskRepo.findOneByOrFail({ taskId: stranded.taskId });
+    expect(after.status).toBe(TaskStatus.Queued);
+    expect(after.progress ?? null).toBeNull();
+  });
+
+  it("promotes a Waiting task whose single parent step is Completed", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+    const parent = makeTask(workflow, 1, TaskStatus.Completed, null);
+    const child = makeTask(workflow, 2, TaskStatus.Waiting, [1]);
+    await taskRepo.save([parent, child]);
+
+    const result = await reconcileTasks(dataSource);
+
+    expect(result).toEqual({ reset: 0, promoted: 1 });
+    const childAfter = await taskRepo.findOneByOrFail({ taskId: child.taskId });
+    expect(childAfter.status).toBe(TaskStatus.Queued);
+  });
+
+  it("leaves a Waiting task with mixed Completed and Waiting parents as Waiting", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+    const parent1 = makeTask(workflow, 1, TaskStatus.Completed, null);
+    const parent2 = makeTask(workflow, 2, TaskStatus.Waiting, null);
+    const child = makeTask(workflow, 3, TaskStatus.Waiting, [1, 2]);
+    await taskRepo.save([parent1, parent2, child]);
+
+    const result = await reconcileTasks(dataSource);
+
+    expect(result.promoted).toBe(0);
+    const childAfter = await taskRepo.findOneByOrFail({ taskId: child.taskId });
+    expect(childAfter.status).toBe(TaskStatus.Waiting);
+  });
+
+  it("leaves a Waiting task with a Failed parent as Waiting (Failed is not Completed)", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+    const parent = makeTask(workflow, 1, TaskStatus.Failed, null);
+    const child = makeTask(workflow, 2, TaskStatus.Waiting, [1]);
+    await taskRepo.save([parent, child]);
+
+    const result = await reconcileTasks(dataSource);
+
+    expect(result.promoted).toBe(0);
+    const childAfter = await taskRepo.findOneByOrFail({ taskId: child.taskId });
+    expect(childAfter.status).toBe(TaskStatus.Waiting);
+  });
+
+  it("recovers multiple stranded rows and never touches Completed or Failed tasks", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+    const completed = makeTask(workflow, 1, TaskStatus.Completed, null, {
+      output: '{"ok":true}',
+    });
+    const failed = makeTask(workflow, 2, TaskStatus.Failed, null, {
+      error: "boom",
+    });
+    const stranded1 = makeTask(workflow, 3, TaskStatus.InProgress, null, {
+      progress: "halfway",
+    });
+    const stranded2 = makeTask(workflow, 4, TaskStatus.InProgress, null, {
+      progress: "nearly",
+    });
+    const promotable = makeTask(workflow, 5, TaskStatus.Waiting, [1]);
+    await taskRepo.save([completed, failed, stranded1, stranded2, promotable]);
+
+    const result = await reconcileTasks(dataSource);
+
+    expect(result).toEqual({ reset: 2, promoted: 1 });
+    const completedAfter = await taskRepo.findOneByOrFail({ taskId: completed.taskId });
+    const failedAfter = await taskRepo.findOneByOrFail({ taskId: failed.taskId });
+    expect(completedAfter.status).toBe(TaskStatus.Completed);
+    expect(completedAfter.output).toBe('{"ok":true}');
+    expect(failedAfter.status).toBe(TaskStatus.Failed);
+    expect(failedAfter.error).toBe("boom");
+    const s1 = await taskRepo.findOneByOrFail({ taskId: stranded1.taskId });
+    const s2 = await taskRepo.findOneByOrFail({ taskId: stranded2.taskId });
+    expect(s1.status).toBe(TaskStatus.Queued);
+    expect(s1.progress ?? null).toBeNull();
+    expect(s2.status).toBe(TaskStatus.Queued);
+    expect(s2.progress ?? null).toBeNull();
+    const promotableAfter = await taskRepo.findOneByOrFail({ taskId: promotable.taskId });
+    expect(promotableAfter.status).toBe(TaskStatus.Queued);
+  });
+});

--- a/tests/workers/taskRunner.cascade.test.ts
+++ b/tests/workers/taskRunner.cascade.test.ts
@@ -1,0 +1,192 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { EmailNotificationJob } from "../../src/jobs/EmailNotificationJob";
+import { PolygonAreaJob } from "../../src/jobs/PolygonAreaJob";
+
+describe("TaskRunner fail-fast cascade on task failure", () => {
+  let dataSource: DataSource;
+
+  const validGeoJson = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [
+        [-63.624885020050996, -10.311050368263523],
+        [-63.624885020050996, -10.367865108370523],
+        [-63.61278302732815, -10.367865108370523],
+        [-63.61278302732815, -10.311050368263523],
+        [-63.624885020050996, -10.311050368263523],
+      ],
+    ],
+  });
+
+  const invalidGeoJson = "this is not json";
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: "sqlite",
+      database: ":memory:",
+      dropSchema: true,
+      synchronize: true,
+      entities: [Task, Result, Workflow],
+    });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+    vi.restoreAllMocks();
+  });
+
+  async function seedWorkflow(): Promise<Workflow> {
+    const workflowRepo = dataSource.getRepository(Workflow);
+    const workflow = new Workflow();
+    workflow.clientId = "client-test";
+    workflow.status = WorkflowStatus.Initial;
+    return await workflowRepo.save(workflow);
+  }
+
+  function makeTask(
+    workflow: Workflow,
+    stepNumber: number,
+    status: TaskStatus,
+    dependency: number[] | null,
+    taskType = "polygonArea",
+    geoJson: string = validGeoJson,
+  ): Task {
+    const task = new Task();
+    task.clientId = "client-test";
+    task.geoJson = geoJson;
+    task.taskType = taskType;
+    task.status = status;
+    task.stepNumber = stepNumber;
+    task.dependency = dependency ? JSON.stringify(dependency) : null;
+    task.workflow = workflow;
+    return task;
+  }
+
+  it("single-level: when A fails, B (deps A) is Failed with skip reason and B's job never runs", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const a = makeTask(workflow, 1, TaskStatus.Queued, null, "polygonArea", invalidGeoJson);
+    const b = makeTask(workflow, 2, TaskStatus.Waiting, [1], "notification");
+    await taskRepo.save([a, b]);
+
+    const emailSpy = vi.spyOn(EmailNotificationJob.prototype, "run");
+
+    const runner = new TaskRunner(taskRepo);
+    await expect(runner.run(a)).rejects.toThrow();
+
+    const aAfter = await taskRepo.findOneByOrFail({ taskId: a.taskId });
+    const bAfter = await taskRepo.findOneByOrFail({ taskId: b.taskId });
+
+    expect(aAfter.status).toBe(TaskStatus.Failed);
+    expect(aAfter.progress).toBeNull();
+    expect(aAfter.error).toBeTruthy();
+
+    expect(bAfter.status).toBe(TaskStatus.Failed);
+    expect(bAfter.progress).toBeNull();
+    expect(bAfter.error).toBe("Skipped: dependency 1 failed");
+
+    expect(emailSpy).not.toHaveBeenCalled();
+
+    const wfRepo = dataSource.getRepository(Workflow);
+    const wfAfter = await wfRepo.findOneByOrFail({ workflowId: workflow.workflowId });
+    expect(wfAfter.status).toBe(WorkflowStatus.Failed);
+  });
+
+  it("multi-level: A fails cascades to B (deps A) and transitively to C (deps B); neither runs", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const a = makeTask(workflow, 1, TaskStatus.Queued, null, "polygonArea", invalidGeoJson);
+    const b = makeTask(workflow, 2, TaskStatus.Waiting, [1], "notification");
+    const c = makeTask(workflow, 3, TaskStatus.Waiting, [2], "notification");
+    await taskRepo.save([a, b, c]);
+
+    const emailSpy = vi.spyOn(EmailNotificationJob.prototype, "run");
+
+    const runner = new TaskRunner(taskRepo);
+    await expect(runner.run(a)).rejects.toThrow();
+
+    const bAfter = await taskRepo.findOneByOrFail({ taskId: b.taskId });
+    const cAfter = await taskRepo.findOneByOrFail({ taskId: c.taskId });
+
+    expect(bAfter.status).toBe(TaskStatus.Failed);
+    expect(bAfter.error).toBe("Skipped: dependency 1 failed");
+
+    expect(cAfter.status).toBe(TaskStatus.Failed);
+    expect(cAfter.error).toBe("Skipped: dependency 2 failed");
+
+    expect(emailSpy).not.toHaveBeenCalled();
+  });
+
+  it("diamond: A completes, B (deps A) fails, C (deps A) completes, D (deps B,C) is cascaded", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const a = makeTask(workflow, 1, TaskStatus.Queued, null, "polygonArea", validGeoJson);
+    const b = makeTask(workflow, 2, TaskStatus.Waiting, [1], "polygonArea", invalidGeoJson);
+    const c = makeTask(workflow, 3, TaskStatus.Waiting, [1], "notification");
+    const d = makeTask(workflow, 4, TaskStatus.Waiting, [2, 3], "notification");
+    await taskRepo.save([a, b, c, d]);
+
+    const runner = new TaskRunner(taskRepo);
+
+    await runner.run(a);
+
+    const bAfterA = await taskRepo.findOneByOrFail({ taskId: b.taskId });
+    const cAfterA = await taskRepo.findOneByOrFail({ taskId: c.taskId });
+    expect(bAfterA.status).toBe(TaskStatus.Queued);
+    expect(cAfterA.status).toBe(TaskStatus.Queued);
+
+    const bReload = await taskRepo.findOneOrFail({ where: { taskId: b.taskId }, relations: ["workflow"] });
+    await expect(runner.run(bReload)).rejects.toThrow();
+
+    const bAfter = await taskRepo.findOneByOrFail({ taskId: b.taskId });
+    const cAfter = await taskRepo.findOneByOrFail({ taskId: c.taskId });
+    const dAfter = await taskRepo.findOneByOrFail({ taskId: d.taskId });
+
+    expect(bAfter.status).toBe(TaskStatus.Failed);
+    expect(cAfter.status).toBe(TaskStatus.Queued);
+    expect(dAfter.status).toBe(TaskStatus.Failed);
+    expect(dAfter.error).toBe("Skipped: dependency 2 failed");
+
+    const cReload = await taskRepo.findOneOrFail({ where: { taskId: c.taskId }, relations: ["workflow"] });
+    await runner.run(cReload);
+
+    const cFinal = await taskRepo.findOneByOrFail({ taskId: c.taskId });
+    const dFinal = await taskRepo.findOneByOrFail({ taskId: d.taskId });
+    expect(cFinal.status).toBe(TaskStatus.Completed);
+    expect(dFinal.status).toBe(TaskStatus.Failed);
+    expect(dFinal.error).toBe("Skipped: dependency 2 failed");
+  });
+
+  it("transactional: cascade updates occur within a manager.transaction call", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const a = makeTask(workflow, 1, TaskStatus.Queued, null, "polygonArea", invalidGeoJson);
+    const b = makeTask(workflow, 2, TaskStatus.Waiting, [1], "notification");
+    await taskRepo.save([a, b]);
+
+    const txSpy = vi.spyOn(taskRepo.manager, "transaction");
+
+    const runner = new TaskRunner(taskRepo);
+    await expect(runner.run(a)).rejects.toThrow();
+
+    expect(txSpy).toHaveBeenCalledTimes(1);
+
+    const bAfter = await taskRepo.findOneByOrFail({ taskId: b.taskId });
+    expect(bAfter.status).toBe(TaskStatus.Failed);
+    expect(bAfter.error).toBe("Skipped: dependency 1 failed");
+  });
+});

--- a/tests/workers/taskRunner.context.test.ts
+++ b/tests/workers/taskRunner.context.test.ts
@@ -1,0 +1,149 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { Job, JobContext } from "../../src/jobs/Job";
+
+const capturedContexts: Array<JobContext | undefined> = [];
+
+class SpyJob implements Job {
+  async run(_task: Task, context?: JobContext): Promise<string> {
+    capturedContexts.push(context);
+    return "spy-output";
+  }
+}
+
+vi.mock("../../src/jobs/JobFactory", () => ({
+  getJobForTaskType: (_taskType: string) => new SpyJob(),
+}));
+
+describe("TaskRunner builds JobContext from persisted parent outputs", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    capturedContexts.length = 0;
+    dataSource = new DataSource({
+      type: "sqlite",
+      database: ":memory:",
+      dropSchema: true,
+      synchronize: true,
+      entities: [Task, Result, Workflow],
+    });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  async function seedWorkflow(): Promise<Workflow> {
+    const wf = new Workflow();
+    wf.clientId = "c1";
+    wf.status = WorkflowStatus.InProgress;
+    return await dataSource.getRepository(Workflow).save(wf);
+  }
+
+  function makeTask(
+    wf: Workflow,
+    stepNumber: number,
+    status: TaskStatus,
+    dependency: number[] | null,
+    output: string | null,
+    taskType = "polygonArea",
+  ): Task {
+    const t = new Task();
+    t.clientId = "c1";
+    t.geoJson = "{}";
+    t.taskType = taskType;
+    t.status = status;
+    t.stepNumber = stepNumber;
+    t.dependency = dependency ? JSON.stringify(dependency) : null;
+    t.output = output;
+    t.workflow = wf;
+    return t;
+  }
+
+  it("passes dependencyOutputs populated from single parent's Task.output", async () => {
+    const wf = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const parent = makeTask(wf, 1, TaskStatus.Completed, null, JSON.stringify(42));
+    const child = makeTask(wf, 2, TaskStatus.Queued, [1], null, "reportGeneration");
+    await taskRepo.save([parent, child]);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(child);
+
+    expect(capturedContexts).toHaveLength(1);
+    const ctx = capturedContexts[0];
+    expect(ctx).toBeDefined();
+    expect(ctx!.dependencyOutputs).toEqual({ 1: 42 });
+  });
+
+  it("fan-in: puts BOTH parents in dependencyOutputs keyed by stepNumber", async () => {
+    const wf = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const parent1 = makeTask(wf, 1, TaskStatus.Completed, null, JSON.stringify(100));
+    const parent2 = makeTask(wf, 2, TaskStatus.Completed, null, JSON.stringify("Brazil"), "analysis");
+    const child = makeTask(wf, 3, TaskStatus.Queued, [1, 2], null, "reportGeneration");
+    await taskRepo.save([parent1, parent2, child]);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(child);
+
+    expect(capturedContexts).toHaveLength(1);
+    const ctx = capturedContexts[0]!;
+    expect(ctx.dependencyOutputs).toEqual({ 1: 100, 2: "Brazil" });
+    expect(ctx.dependencies).toBeDefined();
+    expect(ctx.dependencies).toHaveLength(2);
+    expect(ctx.dependencies!.map(d => d.stepNumber).sort()).toEqual([1, 2]);
+  });
+
+  it("task with no dependency still runs (context is undefined or has empty deps)", async () => {
+    const wf = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const solo = makeTask(wf, 1, TaskStatus.Queued, null, null);
+    await taskRepo.save(solo);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(solo);
+
+    expect(capturedContexts).toHaveLength(1);
+    const ctx = capturedContexts[0];
+    if (ctx !== undefined) {
+      expect(Object.keys(ctx.dependencyOutputs)).toHaveLength(0);
+      expect(ctx.dependencies ?? []).toHaveLength(0);
+    }
+
+    const persisted = await taskRepo.findOneByOrFail({ taskId: solo.taskId });
+    expect(persisted.status).toBe(TaskStatus.Completed);
+  });
+
+  it("parent with output=null surfaces in dependencyOutputs with value null (key present)", async () => {
+    const wf = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const parent = makeTask(wf, 1, TaskStatus.Completed, null, null, "notification");
+    const child = makeTask(wf, 2, TaskStatus.Queued, [1], null, "reportGeneration");
+    await taskRepo.save([parent, child]);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(child);
+
+    expect(capturedContexts).toHaveLength(1);
+    const ctx = capturedContexts[0]!;
+    expect(Object.prototype.hasOwnProperty.call(ctx.dependencyOutputs, 1)).toBe(true);
+    expect(ctx.dependencyOutputs[1]).toBeNull();
+    expect(ctx.dependencies).toBeDefined();
+    expect(ctx.dependencies).toHaveLength(1);
+    expect(ctx.dependencies![0].output).toBeNull();
+  });
+});

--- a/tests/workers/taskRunner.finalResult.test.ts
+++ b/tests/workers/taskRunner.finalResult.test.ts
@@ -1,0 +1,175 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+
+describe("TaskRunner writes Workflow.finalResult on terminal transition", () => {
+  let dataSource: DataSource;
+
+  const validGeoJson = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [
+        [-63.624885020050996, -10.311050368263523],
+        [-63.624885020050996, -10.367865108370523],
+        [-63.61278302732815, -10.367865108370523],
+        [-63.61278302732815, -10.311050368263523],
+        [-63.624885020050996, -10.311050368263523],
+      ],
+    ],
+  });
+
+  const invalidGeoJson = "this is not json";
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: "sqlite",
+      database: ":memory:",
+      dropSchema: true,
+      synchronize: true,
+      entities: [Task, Result, Workflow],
+    });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  async function seedWorkflow(): Promise<Workflow> {
+    const workflowRepo = dataSource.getRepository(Workflow);
+    const workflow = new Workflow();
+    workflow.clientId = "client-test";
+    workflow.status = WorkflowStatus.Initial;
+    return await workflowRepo.save(workflow);
+  }
+
+  function makeTask(
+    workflow: Workflow,
+    stepNumber: number,
+    status: TaskStatus,
+    dependency: number[] | null,
+    taskType = "polygonArea",
+    geoJson: string = validGeoJson,
+  ): Task {
+    const task = new Task();
+    task.clientId = "client-test";
+    task.geoJson = geoJson;
+    task.taskType = taskType;
+    task.status = status;
+    task.stepNumber = stepNumber;
+    task.dependency = dependency ? JSON.stringify(dependency) : null;
+    task.workflow = workflow;
+    return task;
+  }
+
+  it("writes a JSON finalResult summarising all tasks when workflow completes", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const t1 = makeTask(workflow, 1, TaskStatus.Queued, null);
+    const t2 = makeTask(workflow, 2, TaskStatus.Waiting, [1]);
+    await taskRepo.save([t1, t2]);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(t1);
+
+    const t2Reload = await taskRepo.findOneOrFail({ where: { taskId: t2.taskId }, relations: ["workflow"] });
+    await runner.run(t2Reload);
+
+    const wfRepo = dataSource.getRepository(Workflow);
+    const wfAfter = await wfRepo.findOneByOrFail({ workflowId: workflow.workflowId });
+
+    expect(wfAfter.status).toBe(WorkflowStatus.Completed);
+    expect(wfAfter.finalResult).toBeTruthy();
+
+    const parsed = JSON.parse(wfAfter.finalResult as string);
+    expect(parsed.workflowId).toBe(workflow.workflowId);
+    expect(parsed.status).toBe("completed");
+    expect(parsed.completedTasks).toBe(2);
+    expect(parsed.totalTasks).toBe(2);
+    expect(parsed.tasks.map((t: any) => t.stepNumber)).toEqual([1, 2]);
+    for (const task of parsed.tasks) {
+      expect(task.status).toBe("completed");
+      expect(task).toHaveProperty("output");
+    }
+  });
+
+  it("includes failing task error and cascade-skip reasons for dependents on failed workflow", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const a = makeTask(workflow, 1, TaskStatus.Queued, null, "polygonArea", invalidGeoJson);
+    const b = makeTask(workflow, 2, TaskStatus.Waiting, [1], "notification");
+    const c = makeTask(workflow, 3, TaskStatus.Waiting, [2], "notification");
+    await taskRepo.save([a, b, c]);
+
+    const runner = new TaskRunner(taskRepo);
+    await expect(runner.run(a)).rejects.toThrow();
+
+    const wfRepo = dataSource.getRepository(Workflow);
+    const wfAfter = await wfRepo.findOneByOrFail({ workflowId: workflow.workflowId });
+
+    expect(wfAfter.status).toBe(WorkflowStatus.Failed);
+    expect(wfAfter.finalResult).toBeTruthy();
+
+    const parsed = JSON.parse(wfAfter.finalResult as string);
+    expect(parsed.status).toBe("failed");
+    expect(parsed.tasks.map((t: any) => t.stepNumber)).toEqual([1, 2, 3]);
+    expect(parsed.tasks[0].error).toBeTruthy();
+    expect(parsed.tasks[0].error).not.toMatch(/^Skipped:/);
+    expect(parsed.tasks[1].error).toBe("Skipped: dependency 1 failed");
+    expect(parsed.tasks[2].error).toBe("Skipped: dependency 2 failed");
+  });
+
+  it("orders fan-in workflow tasks by stepNumber with each output", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const p1 = makeTask(workflow, 1, TaskStatus.Queued, null);
+    const p2 = makeTask(workflow, 2, TaskStatus.Queued, null);
+    const child = makeTask(workflow, 3, TaskStatus.Waiting, [1, 2]);
+    await taskRepo.save([p1, p2, child]);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(p1);
+    await runner.run(p2);
+
+    const childReload = await taskRepo.findOneOrFail({ where: { taskId: child.taskId }, relations: ["workflow"] });
+    await runner.run(childReload);
+
+    const wfRepo = dataSource.getRepository(Workflow);
+    const wfAfter = await wfRepo.findOneByOrFail({ workflowId: workflow.workflowId });
+
+    expect(wfAfter.status).toBe(WorkflowStatus.Completed);
+    const parsed = JSON.parse(wfAfter.finalResult as string);
+    expect(parsed.tasks.map((t: any) => t.stepNumber)).toEqual([1, 2, 3]);
+    for (const task of parsed.tasks) {
+      expect(task.status).toBe("completed");
+      expect(task).toHaveProperty("output");
+    }
+  });
+
+  it("only populates finalResult when workflow reaches a terminal state", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const t1 = makeTask(workflow, 1, TaskStatus.Queued, null);
+    const t2 = makeTask(workflow, 2, TaskStatus.Waiting, [1]);
+    await taskRepo.save([t1, t2]);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(t1);
+
+    const wfRepo = dataSource.getRepository(Workflow);
+    const wfMid = await wfRepo.findOneByOrFail({ workflowId: workflow.workflowId });
+    expect(wfMid.status).toBe(WorkflowStatus.InProgress);
+    expect(wfMid.finalResult == null).toBe(true);
+  });
+});

--- a/tests/workers/taskRunner.output.test.ts
+++ b/tests/workers/taskRunner.output.test.ts
@@ -1,0 +1,71 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+
+describe("TaskRunner persists task.output on successful polygonArea run", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: "sqlite",
+      database: ":memory:",
+      dropSchema: true,
+      synchronize: true,
+      entities: [Task, Result, Workflow],
+    });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("writes a stringified JSON number to task.output after polygonArea success", async () => {
+    const workflowRepo = dataSource.getRepository(Workflow);
+    const taskRepo = dataSource.getRepository(Task);
+
+    const workflow = new Workflow();
+    workflow.clientId = "client-test";
+    workflow.status = WorkflowStatus.Initial;
+    await workflowRepo.save(workflow);
+
+    const task = new Task();
+    task.clientId = "client-test";
+    task.taskType = "polygonArea";
+    task.status = TaskStatus.Queued;
+    task.stepNumber = 1;
+    task.workflow = workflow;
+    task.geoJson = JSON.stringify({
+      type: "Polygon",
+      coordinates: [
+        [
+          [-63.624885020050996, -10.311050368263523],
+          [-63.624885020050996, -10.367865108370523],
+          [-63.61278302732815, -10.367865108370523],
+          [-63.61278302732815, -10.311050368263523],
+          [-63.624885020050996, -10.311050368263523],
+        ],
+      ],
+    });
+    await taskRepo.save(task);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(task);
+
+    const persisted = await taskRepo.findOneByOrFail({ taskId: task.taskId });
+
+    expect(persisted.status).toBe(TaskStatus.Completed);
+    expect(persisted.output).toBeTruthy();
+    const parsed = JSON.parse(persisted.output as string);
+    expect(typeof parsed).toBe("number");
+    expect(parsed).toBeGreaterThan(8_000_000);
+    expect(parsed).toBeLessThan(9_000_000);
+  });
+});

--- a/tests/workers/taskRunner.promotion.test.ts
+++ b/tests/workers/taskRunner.promotion.test.ts
@@ -1,0 +1,128 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+
+describe("TaskRunner promotes Waiting children when dependencies complete", () => {
+  let dataSource: DataSource;
+
+  const geoJson = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [
+        [-63.624885020050996, -10.311050368263523],
+        [-63.624885020050996, -10.367865108370523],
+        [-63.61278302732815, -10.367865108370523],
+        [-63.61278302732815, -10.311050368263523],
+        [-63.624885020050996, -10.311050368263523],
+      ],
+    ],
+  });
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: "sqlite",
+      database: ":memory:",
+      dropSchema: true,
+      synchronize: true,
+      entities: [Task, Result, Workflow],
+    });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  async function seedWorkflow(): Promise<Workflow> {
+    const workflowRepo = dataSource.getRepository(Workflow);
+    const workflow = new Workflow();
+    workflow.clientId = "client-test";
+    workflow.status = WorkflowStatus.Initial;
+    return await workflowRepo.save(workflow);
+  }
+
+  function makeTask(
+    workflow: Workflow,
+    stepNumber: number,
+    status: TaskStatus,
+    dependency: number[] | null,
+    taskType = "polygonArea",
+  ): Task {
+    const task = new Task();
+    task.clientId = "client-test";
+    task.geoJson = geoJson;
+    task.taskType = taskType;
+    task.status = status;
+    task.stepNumber = stepNumber;
+    task.dependency = dependency ? JSON.stringify(dependency) : null;
+    task.workflow = workflow;
+    return task;
+  }
+
+  it("promotes a Waiting child whose single parent just completed to Queued", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const parent = makeTask(workflow, 1, TaskStatus.Queued, null);
+    const child = makeTask(workflow, 2, TaskStatus.Waiting, [1], "notification");
+    await taskRepo.save([parent, child]);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(parent);
+
+    const parentAfter = await taskRepo.findOneByOrFail({ taskId: parent.taskId });
+    const childAfter = await taskRepo.findOneByOrFail({ taskId: child.taskId });
+
+    expect(parentAfter.status).toBe(TaskStatus.Completed);
+    expect(childAfter.status).toBe(TaskStatus.Queued);
+  });
+
+  it("keeps a Waiting child with multiple parents Waiting until ALL parents are completed", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const parent1 = makeTask(workflow, 1, TaskStatus.Queued, null);
+    const parent2 = makeTask(workflow, 2, TaskStatus.Queued, null);
+    const child = makeTask(workflow, 3, TaskStatus.Waiting, [1, 2], "notification");
+    await taskRepo.save([parent1, parent2, child]);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(parent1);
+
+    let childAfter = await taskRepo.findOneByOrFail({ taskId: child.taskId });
+    expect(childAfter.status).toBe(TaskStatus.Waiting);
+
+    await runner.run(parent2);
+
+    childAfter = await taskRepo.findOneByOrFail({ taskId: child.taskId });
+    expect(childAfter.status).toBe(TaskStatus.Queued);
+  });
+
+  it("performs parent completion and child promotion within a single manager.transaction call", async () => {
+    const workflow = await seedWorkflow();
+    const taskRepo = dataSource.getRepository(Task);
+
+    const parent = makeTask(workflow, 1, TaskStatus.Queued, null);
+    const child = makeTask(workflow, 2, TaskStatus.Waiting, [1], "notification");
+    await taskRepo.save([parent, child]);
+
+    const txSpy = vi.spyOn(taskRepo.manager, "transaction");
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(parent);
+
+    expect(txSpy).toHaveBeenCalledTimes(1);
+
+    const parentAfter = await taskRepo.findOneByOrFail({ taskId: parent.taskId });
+    const childAfter = await taskRepo.findOneByOrFail({ taskId: child.taskId });
+    expect(parentAfter.status).toBe(TaskStatus.Completed);
+    expect(childAfter.status).toBe(TaskStatus.Queued);
+  });
+});

--- a/tests/workflows/WorkflowFactory.deps.test.ts
+++ b/tests/workflows/WorkflowFactory.deps.test.ts
@@ -1,0 +1,106 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { WorkflowFactory } from "../../src/workflows/WorkflowFactory";
+import { TaskStatus } from "../../src/workers/taskRunner";
+
+describe("WorkflowFactory dependsOn parsing", () => {
+  let dataSource: DataSource;
+  let tmpFiles: string[] = [];
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: "sqlite",
+      database: ":memory:",
+      dropSchema: true,
+      synchronize: true,
+      entities: [Task, Result, Workflow],
+    });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+    for (const f of tmpFiles) {
+      try { fs.unlinkSync(f); } catch { /* ignore */ }
+    }
+    tmpFiles = [];
+  });
+
+  function writeYaml(content: string): string {
+    const p = path.join(os.tmpdir(), `wf-${Date.now()}-${Math.random()}.yml`);
+    fs.writeFileSync(p, content, "utf8");
+    tmpFiles.push(p);
+    return p;
+  }
+
+  const geoJson = JSON.stringify({
+    type: "Polygon",
+    coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+  });
+
+  it("persists dependency as JSON string and initial status Waiting for steps with dependsOn", async () => {
+    const yamlPath = writeYaml(
+      [
+        'name: "deps_workflow"',
+        "steps:",
+        '  - taskType: "polygonArea"',
+        "    stepNumber: 1",
+        '  - taskType: "analysis"',
+        "    stepNumber: 2",
+        "    dependsOn: [1]",
+      ].join("\n"),
+    );
+
+    const factory = new WorkflowFactory(dataSource);
+    const workflow = await factory.createWorkflowFromYAML(yamlPath, "client-1", geoJson);
+
+    const taskRepo = dataSource.getRepository(Task);
+    const tasks = await taskRepo.find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+    });
+    const byStep = new Map(tasks.map(t => [t.stepNumber, t]));
+
+    expect(byStep.get(1)?.dependency ?? null).toBeNull();
+    expect(byStep.get(1)?.status).toBe(TaskStatus.Queued);
+
+    expect(byStep.get(2)?.dependency).toBe(JSON.stringify([1]));
+    expect(byStep.get(2)?.status).toBe(TaskStatus.Waiting);
+  });
+
+  it("leaves dependency null and status Queued for steps without dependsOn", async () => {
+    const yamlPath = writeYaml(
+      [
+        'name: "no_deps_workflow"',
+        "steps:",
+        '  - taskType: "polygonArea"',
+        "    stepNumber: 1",
+        '  - taskType: "notification"',
+        "    stepNumber: 2",
+      ].join("\n"),
+    );
+
+    const factory = new WorkflowFactory(dataSource);
+    const workflow = await factory.createWorkflowFromYAML(yamlPath, "client-2", geoJson);
+
+    const taskRepo = dataSource.getRepository(Task);
+    const tasks = await taskRepo.find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+    });
+
+    for (const t of tasks) {
+      expect(t.dependency ?? null).toBeNull();
+      expect(t.status).toBe(TaskStatus.Queued);
+    }
+  });
+});

--- a/tests/workflows/workflowSummary.test.ts
+++ b/tests/workflows/workflowSummary.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+import { workflowSummary } from "../../src/workflows/workflowSummary";
+
+describe("workflowSummary", () => {
+  it("returns workflowId, status, and zero counts for an empty workflow", () => {
+    const workflow = {
+      workflowId: "wf-1",
+      status: "initial",
+      tasks: [],
+    } as any;
+
+    expect(workflowSummary(workflow, { includeTasks: false })).toEqual({
+      workflowId: "wf-1",
+      status: "initial",
+      completedTasks: 0,
+      totalTasks: 0,
+    });
+  });
+
+  it("counts totalTasks as the number of tasks in the workflow", () => {
+    const workflow = {
+      workflowId: "wf-2",
+      status: "in_progress",
+      tasks: [
+        { taskId: "t1", stepNumber: 1, taskType: "a", status: "queued" },
+        { taskId: "t2", stepNumber: 2, taskType: "b", status: "queued" },
+        { taskId: "t3", stepNumber: 3, taskType: "c", status: "queued" },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: false });
+
+    expect(result.totalTasks).toBe(3);
+  });
+
+  it("counts only completed-status tasks in completedTasks (failed tasks are excluded)", () => {
+    const workflow = {
+      workflowId: "wf-3",
+      status: "failed",
+      tasks: [
+        { taskId: "t1", stepNumber: 1, taskType: "a", status: "completed", output: "null" },
+        { taskId: "t2", stepNumber: 2, taskType: "b", status: "failed", progress: "boom" },
+        { taskId: "t3", stepNumber: 3, taskType: "c", status: "completed", output: "null" },
+        { taskId: "t4", stepNumber: 4, taskType: "d", status: "queued" },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: false });
+
+    expect(result.completedTasks).toBe(2);
+    expect(result.totalTasks).toBe(4);
+  });
+
+  it("includes tasks[] with completed shape and parsed JSON output when includeTasks is true", () => {
+    const workflow = {
+      workflowId: "wf-4",
+      status: "completed",
+      tasks: [
+        {
+          taskId: "t1",
+          stepNumber: 1,
+          taskType: "polygonArea",
+          status: "completed",
+          output: JSON.stringify(42),
+        },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: true });
+
+    expect(result.tasks).toEqual([
+      {
+        stepNumber: 1,
+        taskId: "t1",
+        taskType: "polygonArea",
+        status: "completed",
+        output: 42,
+      },
+    ]);
+  });
+
+  it("orders tasks[] by stepNumber ascending regardless of input order", () => {
+    const workflow = {
+      workflowId: "wf-5",
+      status: "completed",
+      tasks: [
+        { taskId: "t3", stepNumber: 3, taskType: "c", status: "completed", output: JSON.stringify("c-out") },
+        { taskId: "t1", stepNumber: 1, taskType: "a", status: "completed", output: JSON.stringify("a-out") },
+        { taskId: "t2", stepNumber: 2, taskType: "b", status: "completed", output: JSON.stringify("b-out") },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: true });
+
+    expect(result.tasks?.map(t => t.stepNumber)).toEqual([1, 2, 3]);
+    expect(result.tasks?.map(t => t.taskId)).toEqual(["t1", "t2", "t3"]);
+  });
+
+  it("represents failed tasks with status 'failed' and the error message from progress", () => {
+    const workflow = {
+      workflowId: "wf-6",
+      status: "failed",
+      tasks: [
+        {
+          taskId: "t1",
+          stepNumber: 1,
+          taskType: "polygonArea",
+          status: "failed",
+          progress: "Invalid GeoJSON: geometry.type must be Polygon",
+        },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: true });
+
+    expect(result.tasks).toEqual([
+      {
+        stepNumber: 1,
+        taskId: "t1",
+        taskType: "polygonArea",
+        status: "failed",
+        error: "Invalid GeoJSON: geometry.type must be Polygon",
+      },
+    ]);
+  });
+
+  it("surfaces fail-fast cascade-skipped tasks with their 'Skipped: ...' error string", () => {
+    const workflow = {
+      workflowId: "wf-7",
+      status: "failed",
+      tasks: [
+        {
+          taskId: "t1",
+          stepNumber: 1,
+          taskType: "polygonArea",
+          status: "failed",
+          progress: "boom",
+        },
+        {
+          taskId: "t2",
+          stepNumber: 2,
+          taskType: "reportGeneration",
+          status: "failed",
+          progress: "Skipped: dependency 1 failed",
+        },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: true });
+
+    expect(result.tasks).toEqual([
+      {
+        stepNumber: 1,
+        taskId: "t1",
+        taskType: "polygonArea",
+        status: "failed",
+        error: "boom",
+      },
+      {
+        stepNumber: 2,
+        taskId: "t2",
+        taskType: "reportGeneration",
+        status: "failed",
+        error: "Skipped: dependency 1 failed",
+      },
+    ]);
+    expect(result.completedTasks).toBe(0);
+    expect(result.totalTasks).toBe(2);
+  });
+
+  it("represents non-terminal tasks with their status and includes progress only when present", () => {
+    const workflow = {
+      workflowId: "wf-8",
+      status: "in_progress",
+      tasks: [
+        { taskId: "t1", stepNumber: 1, taskType: "a", status: "waiting", progress: null },
+        { taskId: "t2", stepNumber: 2, taskType: "b", status: "queued" },
+        { taskId: "t3", stepNumber: 3, taskType: "c", status: "in_progress", progress: "halfway" },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: true });
+
+    expect(result.tasks).toEqual([
+      { stepNumber: 1, taskId: "t1", taskType: "a", status: "waiting" },
+      { stepNumber: 2, taskId: "t2", taskType: "b", status: "queued" },
+      { stepNumber: 3, taskId: "t3", taskType: "c", status: "in_progress", progress: "halfway" },
+    ]);
+  });
+
+  it("round-trips structured JSON outputs back into parsed values", () => {
+    const nested = { area: 1234.5, units: "m^2", meta: { iso: true } };
+    const workflow = {
+      workflowId: "wf-9",
+      status: "completed",
+      tasks: [
+        {
+          taskId: "t1",
+          stepNumber: 1,
+          taskType: "polygonArea",
+          status: "completed",
+          output: JSON.stringify(nested),
+        },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: true });
+
+    expect(result.tasks?.[0]).toEqual({
+      stepNumber: 1,
+      taskId: "t1",
+      taskType: "polygonArea",
+      status: "completed",
+      output: nested,
+    });
+  });
+});

--- a/tests/workflows/workflowSummary.test.ts
+++ b/tests/workflows/workflowSummary.test.ts
@@ -168,6 +168,62 @@ describe("workflowSummary", () => {
     expect(result.totalTasks).toBe(2);
   });
 
+  it("prefers task.error over task.progress for failed tasks when both are present", () => {
+    const workflow = {
+      workflowId: "wf-err",
+      status: "failed",
+      tasks: [
+        {
+          taskId: "t1",
+          stepNumber: 1,
+          taskType: "polygonArea",
+          status: "failed",
+          progress: "starting job...",
+          error: "Invalid GeoJSON: geometry.type must be Polygon",
+        },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: true });
+
+    expect(result.tasks).toEqual([
+      {
+        stepNumber: 1,
+        taskId: "t1",
+        taskType: "polygonArea",
+        status: "failed",
+        error: "Invalid GeoJSON: geometry.type must be Polygon",
+      },
+    ]);
+  });
+
+  it("falls back to task.progress for failed tasks when task.error is null/undefined", () => {
+    const workflow = {
+      workflowId: "wf-fb",
+      status: "failed",
+      tasks: [
+        {
+          taskId: "t1",
+          stepNumber: 1,
+          taskType: "polygonArea",
+          status: "failed",
+          progress: "legacy error string",
+          error: null,
+        },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: true });
+
+    expect(result.tasks?.[0]).toEqual({
+      stepNumber: 1,
+      taskId: "t1",
+      taskType: "polygonArea",
+      status: "failed",
+      error: "legacy error string",
+    });
+  });
+
   it("represents non-terminal tasks with their status and includes progress only when present", () => {
     const workflow = {
       workflowId: "wf-8",


### PR DESCRIPTION
## Summary

Delivers the remaining PRD slices on top of the test harness merged in #11. Each issue landed as its own RED-GREEN-REFACTOR commit (TDD skill, vertical slices — tracer bullets, one test → one impl → repeat).

## Commits / issues

- `dd31d22` workflowSummary pure aggregation module — Closes #2
- `1f0f481` PolygonAreaJob + Task.output persistence — Closes #3
- (#4 commit) Dependency-aware scheduling: Waiting status, Task.dependency, dependsOn YAML, transactional promotion — Closes #4
- `bbdc959` JobContext.dependencyOutputs + ReportGenerationJob — Closes #6
- (#5 commit) Fail-fast cascade on task failure + Task.error column — Closes #5
- `2d62d7e` Startup reconciliation sweep — Closes #8
- `af2afe5` Workflow.finalResult terminal snapshot (in-transaction) — Closes #7
- `f8b90b5` HTTP endpoints GET /workflow/:id/{status,results} — Closes #9
- `7189924` Fan-in example workflow YAML + Readme demo + end-to-end integration test — Closes #10

## Verification

- `npm test` → **56/56 passing**
- `npx tsc --noEmit` clean
- Each commit was independently verified by a reviewer agent before the next was started
- Final end-to-end integration test drives all three tasks (polygonArea, analysis, reportGeneration) via `example_workflow.yml` to `completed` and asserts `workflow.finalResult` contains all three outputs ordered by stepNumber

## Design choices (per PRD)

- **Edge-triggered scheduling** — worker poll query stays `findOne({ where: { status: Queued } })`; readiness is an invariant maintained by TaskRunner at transitions, not re-derived every tick
- **Transactional promotion + cascade + finalResult** — all three state-changing responsibilities now happen inside `manager.transaction` alongside the triggering task save
- **Context derived from DB** — `JobContext.dependencyOutputs` rebuilt from persisted `Task.output` on every run, so a restarted task sees the same inputs
- **Framework owns `finalResult`** — a user-authored `ReportGenerationJob` is never required for a workflow to have a terminal snapshot; its output is one item nested inside `finalResult.tasks[]`
- **Startup reconciliation** as a safety net for the narrow crash-mid-transition window

## Out of scope (per PRD)

Retry/backoff, multi-worker coordination, notifications on failure, schema migrations, auth/rate limiting. These are noted in the PRD's Out-of-Scope section.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author.