### PR TITLE
Testing PRD: close ~30 coverage gaps + 3 targeted production fixes

### DIFF
--- a/src/jobs/PolygonAreaJob.ts
+++ b/src/jobs/PolygonAreaJob.ts
@@ -19,6 +19,40 @@ export class PolygonAreaJob implements Job {
             );
         }
 
+        const coordinates =
+            parsed?.type === 'Feature' ? parsed?.geometry?.coordinates : parsed?.coordinates;
+        if (geometryType === 'Polygon') {
+            validatePolygonRings(coordinates);
+        } else {
+            if (!Array.isArray(coordinates)) {
+                throw new Error('Invalid GeoJSON: MultiPolygon coordinates must be an array');
+            }
+            for (const polygon of coordinates) {
+                validatePolygonRings(polygon);
+            }
+        }
+
         return area(parsed);
+    }
+}
+
+function validatePolygonRings(rings: unknown): void {
+    if (!Array.isArray(rings)) {
+        throw new Error('Invalid GeoJSON: Polygon coordinates must be an array of rings');
+    }
+    for (const ring of rings) {
+        if (!Array.isArray(ring) || ring.length < 4) {
+            throw new Error('Invalid GeoJSON: each Polygon ring must have at least 4 coordinates');
+        }
+        const first = ring[0];
+        const last = ring[ring.length - 1];
+        if (
+            !Array.isArray(first) ||
+            !Array.isArray(last) ||
+            first.length !== last.length ||
+            !first.every((v: unknown, i: number) => v === last[i])
+        ) {
+            throw new Error('Invalid GeoJSON: each Polygon ring must be closed (first coord equals last)');
+        }
     }
 }

--- a/src/routes/workflowRoutes.ts
+++ b/src/routes/workflowRoutes.ts
@@ -46,7 +46,14 @@ export function createWorkflowRouter(dataSource: DataSource): Router {
             return;
         }
 
-        const parsed = JSON.parse(workflow.finalResult ?? 'null');
+        if (workflow.finalResult == null) {
+            res.status(500).json({
+                message: `Workflow ${req.params.id} is terminal but has no finalResult`,
+            });
+            return;
+        }
+
+        const parsed = JSON.parse(workflow.finalResult);
         res.status(200).json(parsed);
     });
 

--- a/src/workers/taskRunner.ts
+++ b/src/workers/taskRunner.ts
@@ -31,9 +31,8 @@ export class TaskRunner {
         await this.taskRepository.save(task);
         const job = getJobForTaskType(task.taskType);
 
-        const context = await this.buildJobContext(task);
-
         try {
+            const context = await this.buildJobContext(task);
             console.log(`Starting job ${task.taskType} for task ${task.taskId}...`);
             const taskResult = await job.run(task, context);
             console.log(`Job ${task.taskType} for task ${task.taskId} completed successfully.`);
@@ -170,8 +169,8 @@ export class TaskRunner {
         let deps: number[];
         try {
             deps = JSON.parse(task.dependency);
-        } catch {
-            return undefined;
+        } catch (err: any) {
+            throw new Error(`Invalid Task.dependency JSON: ${err?.message ?? err}`);
         }
         if (!Array.isArray(deps) || deps.length === 0) {
             return undefined;

--- a/tests/_support/buildYaml.ts
+++ b/tests/_support/buildYaml.ts
@@ -1,0 +1,38 @@
+/**
+ * YAML string builders consumed by `WorkflowFactory.createWorkflowFromYAML`
+ * via a temp file. Used by scale tests (story 30, 31, 32, 33) to exercise
+ * 100-step graphs without committing fixture YAML to disk.
+ */
+
+/**
+ * Linear chain: step 1 has no deps; step k (k>1) depends on step k-1.
+ * All steps use `taskType: "polygonArea"`.
+ */
+export function buildLinearChainYaml(n: number): string {
+  if (n < 1) throw new Error("buildLinearChainYaml: n must be >= 1");
+  const lines: string[] = [`name: "linear_chain_${n}"`, "steps:"];
+  for (let k = 1; k <= n; k++) {
+    lines.push(`  - taskType: "polygonArea"`);
+    lines.push(`    stepNumber: ${k}`);
+    if (k > 1) lines.push(`    dependsOn: [${k - 1}]`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Wide fan-in: steps 1..n-1 are independent leaves (`polygonArea`); step n
+ * is a `reportGeneration` aggregator depending on every prior step.
+ */
+export function buildFanInYaml(n: number): string {
+  if (n < 2) throw new Error("buildFanInYaml: n must be >= 2");
+  const lines: string[] = [`name: "fan_in_${n}"`, "steps:"];
+  for (let k = 1; k < n; k++) {
+    lines.push(`  - taskType: "polygonArea"`);
+    lines.push(`    stepNumber: ${k}`);
+  }
+  const parents = Array.from({ length: n - 1 }, (_, i) => i + 1).join(", ");
+  lines.push(`  - taskType: "reportGeneration"`);
+  lines.push(`    stepNumber: ${n}`);
+  lines.push(`    dependsOn: [${parents}]`);
+  return lines.join("\n") + "\n";
+}

--- a/tests/_support/drainQueuedTasks.ts
+++ b/tests/_support/drainQueuedTasks.ts
@@ -1,0 +1,34 @@
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
+
+/**
+ * Inlined taskWorker loop (no setTimeout) — runs `TaskRunner` against every
+ * Queued task until none remain. Lifted from
+ * `tests/integration/fanInWorkflow.test.ts` so the new integration tests
+ * (cascade, mid-drain, recovery) and scale tests can reuse the same drain
+ * pattern. The `maxIterations` safety bound prevents infinite loops if a
+ * bug leaves tasks queued; defaults to 200 to accommodate 100-task scale
+ * workflows.
+ */
+export async function drainQueuedTasks(
+  dataSource: DataSource,
+  maxIterations: number = 200,
+): Promise<void> {
+  const taskRepository = dataSource.getRepository(Task);
+  const runner = new TaskRunner(taskRepository);
+
+  for (let i = 0; i < maxIterations; i++) {
+    const next = await taskRepository.findOne({
+      where: { status: TaskStatus.Queued },
+      relations: ["workflow"],
+    });
+    if (!next) return;
+    try {
+      await runner.run(next);
+    } catch {
+      // TaskRunner has already marked the task failed; keep draining.
+    }
+  }
+  throw new Error("drainQueuedTasks: exceeded max iterations");
+}

--- a/tests/_support/makeDataSource.ts
+++ b/tests/_support/makeDataSource.ts
@@ -1,0 +1,21 @@
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+
+/**
+ * Returns a fresh, initialized in-memory SQLite DataSource configured with
+ * the workflow engine entities. Mirrors the beforeEach setup used across
+ * tests/workers, tests/workflows, tests/routes, and tests/integration.
+ */
+export async function makeDataSource(): Promise<DataSource> {
+  const dataSource = new DataSource({
+    type: "sqlite",
+    database: ":memory:",
+    dropSchema: true,
+    synchronize: true,
+    entities: [Task, Result, Workflow],
+  });
+  await dataSource.initialize();
+  return dataSource;
+}

--- a/tests/_support/makeTask.ts
+++ b/tests/_support/makeTask.ts
@@ -1,0 +1,54 @@
+import { Task } from "../../src/models/Task";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskStatus } from "../../src/workers/taskRunner";
+
+/**
+ * Default valid GeoJSON polygon (Brazil square) reused across worker tests.
+ */
+export const validGeoJson = JSON.stringify({
+  type: "Polygon",
+  coordinates: [
+    [
+      [-63.624885020050996, -10.311050368263523],
+      [-63.624885020050996, -10.367865108370523],
+      [-63.61278302732815, -10.367865108370523],
+      [-63.61278302732815, -10.311050368263523],
+      [-63.624885020050996, -10.311050368263523],
+    ],
+  ],
+});
+
+export interface MakeTaskOptions {
+  dependency?: number[] | null;
+  taskType?: string;
+  geoJson?: string;
+  output?: string | null;
+  clientId?: string;
+  /** Arbitrary extra Task fields applied last (e.g. `progress`, `error`). */
+  overrides?: Partial<Task>;
+}
+
+/**
+ * Builds an unsaved Task entity wired to `workflow`. Defaults match the
+ * inlined `makeTask` helpers across tests/workers (clientId="client-test",
+ * taskType="polygonArea", geoJson=validGeoJson). Caller is responsible for
+ * persisting via `taskRepo.save(...)`.
+ */
+export function makeTask(
+  workflow: Workflow,
+  stepNumber: number,
+  status: TaskStatus,
+  opts: MakeTaskOptions = {},
+): Task {
+  const task = new Task();
+  task.clientId = opts.clientId ?? "client-test";
+  task.geoJson = opts.geoJson ?? validGeoJson;
+  task.taskType = opts.taskType ?? "polygonArea";
+  task.status = status;
+  task.stepNumber = stepNumber;
+  task.dependency = opts.dependency ? JSON.stringify(opts.dependency) : null;
+  if (opts.output !== undefined) task.output = opts.output;
+  task.workflow = workflow;
+  if (opts.overrides) Object.assign(task, opts.overrides);
+  return task;
+}

--- a/tests/_support/seedWorkflow.ts
+++ b/tests/_support/seedWorkflow.ts
@@ -1,0 +1,20 @@
+import { DataSource } from "typeorm";
+import { Workflow } from "../../src/models/Workflow";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+
+/**
+ * Saves and returns a Workflow row using the test-default fields
+ * (`clientId="client-test"`, `status=Initial`). Pass `overrides` to
+ * customise any field before save (e.g. `{ status: WorkflowStatus.InProgress }`).
+ */
+export async function seedWorkflow(
+  dataSource: DataSource,
+  overrides: Partial<Workflow> = {},
+): Promise<Workflow> {
+  const workflowRepo = dataSource.getRepository(Workflow);
+  const workflow = new Workflow();
+  workflow.clientId = "client-test";
+  workflow.status = WorkflowStatus.Initial;
+  Object.assign(workflow, overrides);
+  return await workflowRepo.save(workflow);
+}

--- a/tests/integration/cascadeWorkflow.test.ts
+++ b/tests/integration/cascadeWorkflow.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Story 36 — failure cascade end-to-end via HTTP.
+ *
+ * Inverted counterpart of `tests/integration/fanInWorkflow.test.ts` (the
+ * happy-path fan-in version). Drives the same 3-step example workflow
+ * (polygonArea + analysis -> reportGeneration[deps:1,2]) but with invalid
+ * GeoJSON so step 1 (polygonArea) fails. Locks in the existing TaskRunner
+ * failure semantics: step 1 fails with "Invalid GeoJSON …", step 3
+ * (reportGeneration) is cascade-skipped via "Skipped: dependency 1 failed",
+ * step 2 (analysis, parallel to step 1) is NOT cascaded and instead surfaces
+ * its own JSON-parse error. Workflow transitions to `failed`, finalResult
+ * is populated, and both errors and status are observable via the HTTP
+ * routes.
+ */
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as path from "path";
+import express from "express";
+import request from "supertest";
+import { DataSource } from "typeorm";
+// Side-effect imports: ensure entity classes register their decorators (and
+// the WorkflowStatus enum becomes defined) before WorkflowFactory.ts runs.
+import "../../src/models/Task";
+import "../../src/models/Result";
+import "../../src/models/Workflow";
+import { Task } from "../../src/models/Task";
+import { WorkflowFactory, WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { TaskStatus } from "../../src/workers/taskRunner";
+import { createWorkflowRouter } from "../../src/routes/workflowRoutes";
+import { makeDataSource } from "../_support/makeDataSource";
+import { drainQueuedTasks } from "../_support/drainQueuedTasks";
+
+describe("cascade workflow end-to-end (invalid GeoJSON -> polygonArea fails -> downstream skipped)", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("[story 36] failure cascades end-to-end and surfaces via HTTP", async () => {
+    const yamlPath = path.join(__dirname, "../../src/workflows/example_workflow.yml");
+    const invalidGeoJson = "this is not json";
+    const factory = new WorkflowFactory(dataSource);
+    const workflow = await factory.createWorkflowFromYAML(yamlPath, "demo", invalidGeoJson);
+
+    await drainQueuedTasks(dataSource);
+
+    const app = express();
+    app.use(express.json());
+    app.use("/workflow", createWorkflowRouter(dataSource));
+
+    const statusRes = await request(app).get(`/workflow/${workflow.workflowId}/status`);
+    expect(statusRes.status).toBe(200);
+    expect(statusRes.body).toMatchObject({
+      workflowId: workflow.workflowId,
+      status: WorkflowStatus.Failed,
+      totalTasks: 3,
+    });
+
+    const resultsRes = await request(app).get(`/workflow/${workflow.workflowId}/results`);
+    expect(resultsRes.status).toBe(200);
+
+    const finalResult = resultsRes.body;
+    expect(finalResult.workflowId).toBe(workflow.workflowId);
+    expect(finalResult.status).toBe(WorkflowStatus.Failed);
+    expect(finalResult.totalTasks).toBe(3);
+    expect(Array.isArray(finalResult.tasks)).toBe(true);
+    expect(finalResult.tasks).toHaveLength(3);
+    expect(finalResult.tasks.map((t: any) => t.stepNumber)).toEqual([1, 2, 3]);
+    expect(finalResult.tasks.map((t: any) => t.taskType)).toEqual([
+      "polygonArea",
+      "analysis",
+      "reportGeneration",
+    ]);
+
+    // Per-task error assertions read from the DB rather than `finalResult`
+    // because TaskRunner freezes `Workflow.finalResult` at the first moment
+    // the workflow becomes terminal — i.e. as soon as step 1 (polygonArea)
+    // fails. At that instant step 2 (analysis, no dependency on step 1) is
+    // still `queued`; it later runs + fails on its own JSON.parse, but the
+    // already-frozen `finalResult` is not refreshed. The DB row, by
+    // contrast, reflects every Task's final state after the drain.
+    const taskRepo = dataSource.getRepository(Task);
+    const tasks = await taskRepo.find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+      order: { stepNumber: "ASC" },
+    });
+    expect(tasks).toHaveLength(3);
+    for (const t of tasks) {
+      expect(t.status).toBe(TaskStatus.Failed);
+      expect(typeof t.error).toBe("string");
+      expect((t.error ?? "").length).toBeGreaterThan(0);
+    }
+
+    const byType = (type: string) => tasks.find(t => t.taskType === type)!;
+    expect(byType("polygonArea").error).toMatch(/invalid geojson/i);
+    // Step 3 (reportGeneration) depends transitively on step 1, so the
+    // cascade marks it skipped with the canonical "Skipped: dependency N
+    // failed" message.
+    expect(byType("reportGeneration").error).toMatch(/skipped|dependency.*failed/i);
+    // Step 2 (analysis) is parallel to step 1 — not a downstream dependent
+    // — so it is NOT cascade-skipped. It runs after step 1 fails and
+    // surfaces its own JSON-parse error from `DataAnalysisJob`.
+    expect(byType("analysis").error).toMatch(/json|unexpected token/i);
+  });
+});

--- a/tests/integration/midDrainStatus.test.ts
+++ b/tests/integration/midDrainStatus.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Story 37 — mid-drain status polling shows monotonic InProgress shape via HTTP.
+ *
+ * Drives the example fan-in workflow (polygonArea + analysis ->
+ * reportGeneration[deps:1,2]) and polls GET /workflow/:id/status at three
+ * points across the drain to lock in the workflow-status state machine and
+ * the `completedTasks`/`totalTasks` counters surfaced by `workflowSummary`.
+ *
+ * Three-snapshot pattern:
+ *   1. BEFORE any task runs:  status="initial",     completedTasks=0, totalTasks=3
+ *   2. AFTER one task runs:   status="in_progress", completedTasks=1, totalTasks=3
+ *   3. AFTER full drain:      status="completed",   completedTasks=3, totalTasks=3
+ *
+ * Monotonicity: completedTasks strictly increases between snapshots 1->2 and
+ * is non-decreasing between snapshots 2->3; totalTasks is identical across
+ * all three snapshots.
+ *
+ * Snapshot 2 is taken after running exactly ONE task. `drainQueuedTasks` does
+ * not support an iteration cap that returns cleanly (passing maxIterations=1
+ * would throw), so the single-step drain is inlined here.
+ */
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as path from "path";
+import express from "express";
+import request from "supertest";
+import { DataSource } from "typeorm";
+// Side-effect imports: ensure entity classes register their decorators (and
+// the WorkflowStatus enum becomes defined) before WorkflowFactory.ts runs.
+import "../../src/models/Task";
+import "../../src/models/Result";
+import "../../src/models/Workflow";
+import { Task } from "../../src/models/Task";
+import { WorkflowFactory, WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
+import { createWorkflowRouter } from "../../src/routes/workflowRoutes";
+import { makeDataSource } from "../_support/makeDataSource";
+import { drainQueuedTasks } from "../_support/drainQueuedTasks";
+
+describe("mid-drain status polling end-to-end (fan-in workflow)", () => {
+  let dataSource: DataSource;
+
+  const geoJson = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [
+        [-63.624885020050996, -10.311050368263523],
+        [-63.624885020050996, -10.367865108370523],
+        [-63.61278302732815, -10.367865108370523],
+        [-63.61278302732815, -10.311050368263523],
+        [-63.624885020050996, -10.311050368263523],
+      ],
+    ],
+  });
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("[story 37] mid-drain status polling shows monotonic InProgress shape", async () => {
+    const yamlPath = path.join(__dirname, "../../src/workflows/example_workflow.yml");
+    const factory = new WorkflowFactory(dataSource);
+    const workflow = await factory.createWorkflowFromYAML(yamlPath, "demo", geoJson);
+
+    const app = express();
+    app.use(express.json());
+    app.use("/workflow", createWorkflowRouter(dataSource));
+
+    // Snapshot 1: before any task runs. WorkflowFactory seeds status="initial".
+    const snap1 = await request(app).get(`/workflow/${workflow.workflowId}/status`);
+    expect(snap1.status).toBe(200);
+    expect(snap1.body).toMatchObject({
+      workflowId: workflow.workflowId,
+      status: WorkflowStatus.Initial,
+      completedTasks: 0,
+      totalTasks: 3,
+    });
+
+    // Inlined single-step drain: run exactly one Queued task. (Using
+    // `drainQueuedTasks(dataSource, 1)` would throw "exceeded max iterations"
+    // because the helper's loop bound is checked before re-querying for
+    // remaining work.)
+    const taskRepo = dataSource.getRepository(Task);
+    const runner = new TaskRunner(taskRepo);
+    const firstQueued = await taskRepo.findOne({
+      where: { status: TaskStatus.Queued },
+      relations: ["workflow"],
+    });
+    expect(firstQueued).not.toBeNull();
+    await runner.run(firstQueued!);
+
+    // Snapshot 2: one task complete, workflow transitioned to in_progress.
+    const snap2 = await request(app).get(`/workflow/${workflow.workflowId}/status`);
+    expect(snap2.status).toBe(200);
+    expect(snap2.body).toMatchObject({
+      workflowId: workflow.workflowId,
+      status: WorkflowStatus.InProgress,
+      completedTasks: 1,
+      totalTasks: 3,
+    });
+
+    // Drain the rest.
+    await drainQueuedTasks(dataSource);
+
+    // Snapshot 3: all tasks complete, workflow terminal.
+    const snap3 = await request(app).get(`/workflow/${workflow.workflowId}/status`);
+    expect(snap3.status).toBe(200);
+    expect(snap3.body).toMatchObject({
+      workflowId: workflow.workflowId,
+      status: WorkflowStatus.Completed,
+      completedTasks: 3,
+      totalTasks: 3,
+    });
+
+    // Monotonicity: completedTasks strictly increases 1->2, non-decreasing
+    // 2->3; totalTasks identical across all three snapshots.
+    expect(snap2.body.completedTasks).toBeGreaterThan(snap1.body.completedTasks);
+    expect(snap3.body.completedTasks).toBeGreaterThanOrEqual(snap2.body.completedTasks);
+    expect(snap1.body.totalTasks).toBe(snap2.body.totalTasks);
+    expect(snap2.body.totalTasks).toBe(snap3.body.totalTasks);
+  });
+});

--- a/tests/integration/reconciliationRecovery.test.ts
+++ b/tests/integration/reconciliationRecovery.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Story 38 — reconciliation / crash-recovery end-to-end via HTTP.
+ *
+ * Simulates the operational scenario where a worker process died mid-run
+ * leaving a hand-seeded workflow in an inconsistent shape:
+ *   - Workflow.status = in_progress
+ *   - step 1 (analysis, no deps): Completed (with a valid analysis output)
+ *   - step 2 (analysis, deps [1]): InProgress — STRANDED (the crashed task)
+ *   - step 3 (reportGeneration, deps [2]): Waiting
+ *
+ * Three-snapshot pattern locking in the single-pass reconcile contract
+ * (TESTING_PRD Q6, Q8) and the subsequent end-to-end recovery via the
+ * normal drain loop:
+ *   1. Pre-reconcile: B InProgress, C Waiting.
+ *   2. Post-reconcile, pre-drain: B reset to Queued; C still Waiting
+ *      (single-pass — C not promoted because B is not yet Completed).
+ *   3. Post-drain: workflow.status === completed; A, B, C all Completed;
+ *      GET /:id/results returns 200 with finalResult populated.
+ */
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { DataSource } from "typeorm";
+// Side-effect imports: ensure entity decorators register (and the
+// WorkflowStatus enum is defined) before WorkflowFactory.ts runs.
+import "../../src/models/Task";
+import "../../src/models/Result";
+import "../../src/models/Workflow";
+import { Task } from "../../src/models/Task";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { TaskStatus } from "../../src/workers/taskRunner";
+import { reconcileTasks } from "../../src/workers/reconciliation";
+import { createWorkflowRouter } from "../../src/routes/workflowRoutes";
+import { makeDataSource } from "../_support/makeDataSource";
+import { seedWorkflow } from "../_support/seedWorkflow";
+import { makeTask, validGeoJson } from "../_support/makeTask";
+import { drainQueuedTasks } from "../_support/drainQueuedTasks";
+
+describe("reconciliation crash-recovery end-to-end", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("[story 38] reconciliation recovers stranded workflow and completes via HTTP", async () => {
+    // Seed a workflow already mid-flight: one task done, one stranded
+    // InProgress (the crashed worker), one downstream Waiting.
+    const workflow = await seedWorkflow(dataSource, {
+      status: WorkflowStatus.InProgress,
+    });
+    const taskRepo = dataSource.getRepository(Task);
+    const a = makeTask(workflow, 1, TaskStatus.Completed, {
+      taskType: "analysis",
+      output: JSON.stringify("Brazil"),
+    });
+    const b = makeTask(workflow, 2, TaskStatus.InProgress, {
+      taskType: "analysis",
+      dependency: [1],
+      overrides: { progress: "starting job..." },
+    });
+    const c = makeTask(workflow, 3, TaskStatus.Waiting, {
+      taskType: "reportGeneration",
+      dependency: [2],
+      geoJson: validGeoJson,
+    });
+    await taskRepo.save([a, b, c]);
+
+    const app = express();
+    app.use(express.json());
+    app.use("/workflow", createWorkflowRouter(dataSource));
+
+    // Snapshot 1 — pre-reconcile: B InProgress, C Waiting.
+    const snap1 = await request(app)
+      .get(`/workflow/${workflow.workflowId}/status`)
+      .query({ includeTasks: "true" });
+    expect(snap1.status).toBe(200);
+    expect(snap1.body).toMatchObject({
+      workflowId: workflow.workflowId,
+      status: WorkflowStatus.InProgress,
+      completedTasks: 1,
+      totalTasks: 3,
+    });
+    const byStep1 = (n: number) =>
+      snap1.body.tasks.find((t: any) => t.stepNumber === n);
+    expect(byStep1(1).status).toBe(TaskStatus.Completed);
+    expect(byStep1(2).status).toBe(TaskStatus.InProgress);
+    expect(byStep1(3).status).toBe(TaskStatus.Waiting);
+
+    // Run the startup sweep — single pass: B (InProgress) → Queued, but C
+    // (Waiting) NOT promoted because B is no longer Completed at the
+    // promotion check (per TESTING_PRD Q6 single-pass lock).
+    const sweep = await reconcileTasks(dataSource);
+    expect(sweep).toEqual({ reset: 1, promoted: 0 });
+
+    // Snapshot 2 — post-reconcile, pre-drain: B Queued, C still Waiting.
+    const snap2 = await request(app)
+      .get(`/workflow/${workflow.workflowId}/status`)
+      .query({ includeTasks: "true" });
+    expect(snap2.status).toBe(200);
+    expect(snap2.body).toMatchObject({
+      workflowId: workflow.workflowId,
+      status: WorkflowStatus.InProgress,
+      completedTasks: 1,
+      totalTasks: 3,
+    });
+    const byStep2 = (n: number) =>
+      snap2.body.tasks.find((t: any) => t.stepNumber === n);
+    expect(byStep2(1).status).toBe(TaskStatus.Completed);
+    expect(byStep2(2).status).toBe(TaskStatus.Queued);
+    expect(byStep2(3).status).toBe(TaskStatus.Waiting);
+
+    // Drain queue — B runs, completes; TaskRunner promotes C → Queued in
+    // the same transaction; next iteration runs C → Completed; workflow
+    // transitions to `completed` and finalResult is frozen.
+    await drainQueuedTasks(dataSource);
+
+    // Snapshot 3 — post-drain: workflow completed, all tasks Completed.
+    const snap3 = await request(app)
+      .get(`/workflow/${workflow.workflowId}/status`)
+      .query({ includeTasks: "true" });
+    expect(snap3.status).toBe(200);
+    expect(snap3.body).toMatchObject({
+      workflowId: workflow.workflowId,
+      status: WorkflowStatus.Completed,
+      completedTasks: 3,
+      totalTasks: 3,
+    });
+    for (const step of [1, 2, 3]) {
+      const t = snap3.body.tasks.find((x: any) => x.stepNumber === step);
+      expect(t.status).toBe(TaskStatus.Completed);
+    }
+
+    const resultsRes = await request(app).get(
+      `/workflow/${workflow.workflowId}/results`,
+    );
+    expect(resultsRes.status).toBe(200);
+    expect(resultsRes.body.workflowId).toBe(workflow.workflowId);
+    expect(resultsRes.body.status).toBe(WorkflowStatus.Completed);
+    expect(resultsRes.body.totalTasks).toBe(3);
+    expect(resultsRes.body.completedTasks).toBe(3);
+  });
+});

--- a/tests/jobs/JobFactory.test.ts
+++ b/tests/jobs/JobFactory.test.ts
@@ -1,5 +1,9 @@
+/** Covers TESTING_PRD stories: existing harness smoke test + 15. Prior art: same file. */
 import { describe, it, expect } from "vitest";
 import { getJobForTaskType } from "../../src/jobs/JobFactory";
+import { DataAnalysisJob } from "../../src/jobs/DataAnalysisJob";
+import { EmailNotificationJob } from "../../src/jobs/EmailNotificationJob";
+import { PolygonAreaJob } from "../../src/jobs/PolygonAreaJob";
 import { ReportGenerationJob } from "../../src/jobs/ReportGenerationJob";
 
 describe("test harness smoke test", () => {
@@ -10,5 +14,28 @@ describe("test harness smoke test", () => {
   it("maps 'reportGeneration' to ReportGenerationJob", () => {
     const job = getJobForTaskType("reportGeneration");
     expect(job).toBeInstanceOf(ReportGenerationJob);
+  });
+});
+
+describe("[story 15] taskType resolution", () => {
+  it("[story 15] maps 'polygonArea' to PolygonAreaJob", () => {
+    expect(getJobForTaskType("polygonArea")).toBeInstanceOf(PolygonAreaJob);
+  });
+
+  it("[story 15] maps 'analysis' to DataAnalysisJob", () => {
+    expect(getJobForTaskType("analysis")).toBeInstanceOf(DataAnalysisJob);
+  });
+
+  it("[story 15] maps 'reportGeneration' to ReportGenerationJob", () => {
+    expect(getJobForTaskType("reportGeneration")).toBeInstanceOf(ReportGenerationJob);
+  });
+
+  it("[story 15] maps 'notification' to EmailNotificationJob", () => {
+    expect(getJobForTaskType("notification")).toBeInstanceOf(EmailNotificationJob);
+  });
+
+  it("[story 15] throws an Error whose message contains the unknown taskType", () => {
+    const unknown = "definitelyNotARealTaskType";
+    expect(() => getJobForTaskType(unknown)).toThrow(unknown);
   });
 });

--- a/tests/jobs/PolygonAreaJob.test.ts
+++ b/tests/jobs/PolygonAreaJob.test.ts
@@ -1,3 +1,4 @@
+/** Covers TESTING_PRD stories: existing happy paths + 12, 13. Prior art: same file. */
 import { describe, it, expect } from "vitest";
 import { PolygonAreaJob } from "../../src/jobs/PolygonAreaJob";
 import { Task } from "../../src/models/Task";
@@ -124,5 +125,135 @@ describe("PolygonAreaJob", () => {
     // Roughly ~1.34 km x ~6.3 km rectangular box ≈ 8.4e6 m²
     expect(result).toBeGreaterThan(8_000_000);
     expect(result).toBeLessThan(9_000_000);
+  });
+});
+
+
+describe("[stories 12, 13] invalid-input rejection", () => {
+  it("[story 12] rejects a Polygon ring with fewer than four coordinates", async () => {
+    const job = new PolygonAreaJob();
+    const polygon = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [1, 1],
+          [0, 0],
+        ],
+      ],
+    };
+
+    await expect(job.run(makeTask(polygon))).rejects.toThrow(/invalid geojson/i);
+  });
+
+  it("[story 12] rejects a Polygon with an explicitly unclosed ring", async () => {
+    const job = new PolygonAreaJob();
+    const polygon = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [0, 1],
+          [1, 1],
+          [1, 0],
+        ],
+      ],
+    };
+
+    await expect(job.run(makeTask(polygon))).rejects.toThrow(/invalid geojson/i);
+  });
+
+  it("[story 12] rejects a Feature<Polygon> with an unclosed ring", async () => {
+    const job = new PolygonAreaJob();
+    const feature = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [0, 0],
+            [0, 1],
+            [1, 1],
+            [1, 0],
+          ],
+        ],
+      },
+    };
+
+    await expect(job.run(makeTask(feature))).rejects.toThrow(/invalid geojson/i);
+  });
+
+  it("[story 12] rejects a MultiPolygon when any inner ring is unclosed", async () => {
+    const job = new PolygonAreaJob();
+    const multi = {
+      type: "MultiPolygon",
+      coordinates: [
+        [
+          [
+            [0, 0],
+            [0, 1],
+            [1, 1],
+            [1, 0],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [10, 10],
+            [10, 11],
+            [11, 11],
+            [11, 10],
+          ],
+        ],
+      ],
+    };
+
+    await expect(job.run(makeTask(multi))).rejects.toThrow(/invalid geojson/i);
+  });
+
+  it("[story 12] rejects an empty task.geoJson string", async () => {
+    const job = new PolygonAreaJob();
+    const task = makeTask("");
+
+    await expect(job.run(task)).rejects.toThrow(/invalid geojson/i);
+  });
+
+  it("[story 12] rejects a null task.geoJson value", async () => {
+    const job = new PolygonAreaJob();
+    const task = new Task();
+    task.geoJson = null as unknown as string;
+    task.taskType = "polygonArea";
+
+    await expect(job.run(task)).rejects.toThrow(/invalid geojson/i);
+  });
+
+  it("[story 13] rejects a syntactically valid GeoJSON FeatureCollection", async () => {
+    const job = new PolygonAreaJob();
+    const featureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [0, 0],
+                [0, 1],
+                [1, 1],
+                [1, 0],
+                [0, 0],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+
+    await expect(job.run(makeTask(featureCollection))).rejects.toThrow(
+      /polygon|multipolygon/i,
+    );
   });
 });

--- a/tests/jobs/ReportGenerationJob.test.ts
+++ b/tests/jobs/ReportGenerationJob.test.ts
@@ -1,3 +1,4 @@
+/** Covers TESTING_PRD stories: existing happy paths + 14. Prior art: same file. */
 import { describe, it, expect } from "vitest";
 import { ReportGenerationJob } from "../../src/jobs/ReportGenerationJob";
 import { Task } from "../../src/models/Task";
@@ -82,5 +83,34 @@ describe("ReportGenerationJob", () => {
       output: null,
     });
     expect(result.tasks[0].output).toBeNull();
+  });
+});
+
+describe("[story 14] misconfigured invocation", () => {
+  it("[story 14] returns deterministic empty-report shape when invoked with undefined context", async () => {
+    const job = new ReportGenerationJob();
+    const task = makeReportTask("wf-undef-ctx");
+
+    const result = await job.run(task, undefined);
+
+    expect(result).toEqual({
+      workflowId: "wf-undef-ctx",
+      tasks: [],
+      finalReport: "Aggregated 0 tasks",
+    });
+  });
+
+  it("[story 14] returns deterministic empty-report shape when dependencyOutputs is empty and dependencies omitted", async () => {
+    const job = new ReportGenerationJob();
+    const task = makeReportTask("wf-empty-deps");
+    const context: JobContext = { dependencyOutputs: {} };
+
+    const result = await job.run(task, context);
+
+    expect(result).toEqual({
+      workflowId: "wf-empty-deps",
+      tasks: [],
+      finalReport: "Aggregated 0 tasks",
+    });
   });
 });

--- a/tests/routes/workflowRoutes.test.ts
+++ b/tests/routes/workflowRoutes.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Route tests for `createWorkflowRouter` (`/workflow/:id/status`,
+ * `/workflow/:id/results`).
+ *
+ * Stories covered in the trailing block:
+ *   - [story 19] terminal workflow with finalResult=null → 500
+ *   - [story 20] strict `?includeTasks` matching (only literal "true")
+ *   - [story 21] zero-task workflow `/status`
+ *   - [story 35] 100-task workflow `/status?includeTasks=true`
+ */
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import express from "express";
@@ -9,6 +19,9 @@ import { Workflow } from "../../src/models/Workflow";
 import { TaskStatus } from "../../src/workers/taskRunner";
 import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
 import { createWorkflowRouter } from "../../src/routes/workflowRoutes";
+import { makeDataSource } from "../_support/makeDataSource";
+import { seedWorkflow as seedWorkflowSupport } from "../_support/seedWorkflow";
+import { makeTask as makeTaskSupport } from "../_support/makeTask";
 
 describe("GET /workflow/:id/status and /workflow/:id/results", () => {
   let dataSource: DataSource;
@@ -181,5 +194,149 @@ describe("GET /workflow/:id/status and /workflow/:id/results", () => {
       const res = await request(app).get(`/workflow/unknownid/results`);
       expect(res.status).toBe(404);
     });
+  });
+});
+
+describe("[stories 19, 20, 21, 35] route edge + scale", () => {
+  let dataSource: DataSource;
+  let app: express.Express;
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+    app = express();
+    app.use(express.json());
+    app.use("/workflow", createWorkflowRouter(dataSource));
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("[story 19] returns 500 when terminal workflow has finalResult=null", async () => {
+    const workflow = await seedWorkflowSupport(dataSource, {
+      status: WorkflowStatus.Completed,
+    });
+    // finalResult left as null/undefined intentionally.
+
+    const res = await request(app).get(`/workflow/${workflow.workflowId}/results`);
+
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty("message");
+  });
+
+  describe("[story 20] strict ?includeTasks matching", () => {
+    async function seedWithOneTask(): Promise<Workflow> {
+      const workflow = await seedWorkflowSupport(dataSource, {
+        status: WorkflowStatus.InProgress,
+      });
+      const taskRepo = dataSource.getRepository(Task);
+      await taskRepo.save([
+        makeTaskSupport(workflow, 1, TaskStatus.Completed, {
+          output: JSON.stringify({ area: 1 }),
+        }),
+      ]);
+      return workflow;
+    }
+
+    it('[story 20] "true" → tasks[] present', async () => {
+      const workflow = await seedWithOneTask();
+      const res = await request(app)
+        .get(`/workflow/${workflow.workflowId}/status`)
+        .query({ includeTasks: "true" });
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.tasks)).toBe(true);
+      expect(res.body.tasks).toHaveLength(1);
+    });
+
+    it('[story 20] "1" → tasks[] absent (undefined)', async () => {
+      const workflow = await seedWithOneTask();
+      const res = await request(app)
+        .get(`/workflow/${workflow.workflowId}/status`)
+        .query({ includeTasks: "1" });
+      expect(res.status).toBe(200);
+      expect(res.body.tasks).toBeUndefined();
+    });
+
+    it('[story 20] "TRUE" → tasks[] absent (undefined)', async () => {
+      const workflow = await seedWithOneTask();
+      const res = await request(app)
+        .get(`/workflow/${workflow.workflowId}/status`)
+        .query({ includeTasks: "TRUE" });
+      expect(res.status).toBe(200);
+      expect(res.body.tasks).toBeUndefined();
+    });
+
+    it('[story 20] "" → tasks[] absent (undefined)', async () => {
+      const workflow = await seedWithOneTask();
+      const res = await request(app)
+        .get(`/workflow/${workflow.workflowId}/status`)
+        .query({ includeTasks: "" });
+      expect(res.status).toBe(200);
+      expect(res.body.tasks).toBeUndefined();
+    });
+
+    it("[story 20] omitted → tasks[] absent (undefined)", async () => {
+      const workflow = await seedWithOneTask();
+      const res = await request(app).get(
+        `/workflow/${workflow.workflowId}/status`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.tasks).toBeUndefined();
+    });
+
+    it("[story 20] array (?includeTasks=true&includeTasks=false) → tasks[] absent (undefined)", async () => {
+      const workflow = await seedWithOneTask();
+      const res = await request(app).get(
+        `/workflow/${workflow.workflowId}/status?includeTasks=true&includeTasks=false`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.tasks).toBeUndefined();
+    });
+  });
+
+  it("[story 21] zero-task workflow → /status returns 200 with totalTasks=0, completedTasks=0", async () => {
+    const workflow = await seedWorkflowSupport(dataSource, {
+      status: WorkflowStatus.Initial,
+    });
+
+    const res = await request(app).get(`/workflow/${workflow.workflowId}/status`);
+    expect(res.status).toBe(200);
+    expect(res.body.completedTasks).toBe(0);
+    expect(res.body.totalTasks).toBe(0);
+    expect(res.body.tasks).toBeUndefined();
+
+    const resWithTasks = await request(app)
+      .get(`/workflow/${workflow.workflowId}/status`)
+      .query({ includeTasks: "true" });
+    expect(resWithTasks.status).toBe(200);
+    expect(Array.isArray(resWithTasks.body.tasks)).toBe(true);
+    expect(resWithTasks.body.tasks).toHaveLength(0);
+  });
+
+  it("[story 35] 100-task workflow → /status?includeTasks=true returns all 100 ordered by stepNumber", async () => {
+    const workflow = await seedWorkflowSupport(dataSource, {
+      status: WorkflowStatus.InProgress,
+    });
+    const taskRepo = dataSource.getRepository(Task);
+
+    const stepNumbers = Array.from({ length: 100 }, (_, i) => i + 1);
+    // Insert in shuffled-ish order so we can verify sort.
+    const shuffled = [...stepNumbers].sort(() => 0.5 - Math.random());
+    const tasks = shuffled.map(n =>
+      makeTaskSupport(workflow, n, TaskStatus.Queued),
+    );
+    await taskRepo.save(tasks);
+
+    const res = await request(app)
+      .get(`/workflow/${workflow.workflowId}/status`)
+      .query({ includeTasks: "true" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalTasks).toBe(100);
+    expect(Array.isArray(res.body.tasks)).toBe(true);
+    expect(res.body.tasks).toHaveLength(100);
+    expect(res.body.tasks.map((t: any) => t.stepNumber)).toEqual(stepNumbers);
   });
 });

--- a/tests/workers/reconciliation.test.ts
+++ b/tests/workers/reconciliation.test.ts
@@ -1,3 +1,20 @@
+/**
+ * Reconciliation startup-sweep coverage.
+ *
+ * Stories pinned in this file:
+ *  - existing: stranded InProgress reset to Queued; single-parent Waiting
+ *              promotion; mixed/Failed parents leave child Waiting.
+ *  - story 26: chain A(Completed)→B(Waiting)→C(Waiting) — single sweep
+ *              promotes B only; C stays Waiting (LOCK: single-pass
+ *              one-level promotion — see TESTING_PRD Q6).
+ *  - story 27: combined sweep — stranded InProgress parent X is reset to
+ *              Queued and Waiting child Y stays Waiting (parent is no
+ *              longer Completed at promotion time); reconcileTasks returns
+ *              { reset: 1, promoted: 0 }.
+ *
+ * NOTE: stories 26/27 are LOCK tests. A future fixed-point reconciliation
+ * refactor SHOULD break them, prompting an intentional update.
+ */
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { DataSource } from "typeorm";
@@ -7,6 +24,9 @@ import { Workflow } from "../../src/models/Workflow";
 import { TaskStatus } from "../../src/workers/taskRunner";
 import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
 import { reconcileTasks } from "../../src/workers/reconciliation";
+import { makeDataSource } from "../_support/makeDataSource";
+import { seedWorkflow as seedWorkflowSupport } from "../_support/seedWorkflow";
+import { makeTask as makeTaskSupport } from "../_support/makeTask";
 
 describe("reconcileTasks startup sweep", () => {
   let dataSource: DataSource;
@@ -167,5 +187,59 @@ describe("reconcileTasks startup sweep", () => {
     expect(s2.progress ?? null).toBeNull();
     const promotableAfter = await taskRepo.findOneByOrFail({ taskId: promotable.taskId });
     expect(promotableAfter.status).toBe(TaskStatus.Queued);
+  });
+});
+
+describe("[stories 26, 27] sweep semantics", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("[story 26] chain A(Completed)→B(Waiting)→C(Waiting): single sweep promotes only B; C stays Waiting", async () => {
+    // LOCK: single-pass one-level promotion — see TESTING_PRD Q6
+    const workflow = await seedWorkflowSupport(dataSource);
+    const taskRepo = dataSource.getRepository(Task);
+    const a = makeTaskSupport(workflow, 1, TaskStatus.Completed, { dependency: null });
+    const b = makeTaskSupport(workflow, 2, TaskStatus.Waiting, { dependency: [1] });
+    const c = makeTaskSupport(workflow, 3, TaskStatus.Waiting, { dependency: [2] });
+    await taskRepo.save([a, b, c]);
+
+    const result = await reconcileTasks(dataSource);
+
+    expect(result).toEqual({ reset: 0, promoted: 1 });
+    const aAfter = await taskRepo.findOneByOrFail({ taskId: a.taskId });
+    const bAfter = await taskRepo.findOneByOrFail({ taskId: b.taskId });
+    const cAfter = await taskRepo.findOneByOrFail({ taskId: c.taskId });
+    expect(aAfter.status).toBe(TaskStatus.Completed);
+    expect(bAfter.status).toBe(TaskStatus.Queued);
+    expect(cAfter.status).toBe(TaskStatus.Waiting);
+  });
+
+  it("[story 27] combined sweep: stranded InProgress parent is reset to Queued and Waiting child stays Waiting", async () => {
+    const workflow = await seedWorkflowSupport(dataSource);
+    const taskRepo = dataSource.getRepository(Task);
+    const x = makeTaskSupport(workflow, 1, TaskStatus.InProgress, {
+      dependency: null,
+      overrides: { progress: "interrupted" },
+    });
+    const y = makeTaskSupport(workflow, 2, TaskStatus.Waiting, { dependency: [1] });
+    await taskRepo.save([x, y]);
+
+    const result = await reconcileTasks(dataSource);
+
+    expect(result).toEqual({ reset: 1, promoted: 0 });
+    const xAfter = await taskRepo.findOneByOrFail({ taskId: x.taskId });
+    const yAfter = await taskRepo.findOneByOrFail({ taskId: y.taskId });
+    expect(xAfter.status).toBe(TaskStatus.Queued);
+    expect(xAfter.progress ?? null).toBeNull();
+    expect(yAfter.status).toBe(TaskStatus.Waiting);
   });
 });

--- a/tests/workers/taskRunner.cascade.test.ts
+++ b/tests/workers/taskRunner.cascade.test.ts
@@ -1,3 +1,18 @@
+/**
+ * Fail-fast cascade behavior of TaskRunner.
+ *
+ * Stories pinned in this file:
+ *  - story 23: wide fan-out — a single parent failure cascades to all of its
+ *              waiting dependents (regardless of count) with the per-dependent
+ *              skip-reason referencing the failed parent's stepNumber.
+ *  - story 24: wide fan-in — when one of N parents fails, the shared child is
+ *              cascaded exactly once with a skip reason referencing only the
+ *              failed parent (no double-failure side effects).
+ *  - story 25: two independent failure origins — when two unrelated parents
+ *              both fail, a shared descendant is cascaded only once and its
+ *              skip reason references the lowest-stepNumber failed dependency
+ *              (per TaskRunner's failedDepSteps.sort((a,b)=>a-b)[0] rule).
+ */
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { DataSource } from "typeorm";
@@ -188,5 +203,106 @@ describe("TaskRunner fail-fast cascade on task failure", () => {
     const bAfter = await taskRepo.findOneByOrFail({ taskId: b.taskId });
     expect(bAfter.status).toBe(TaskStatus.Failed);
     expect(bAfter.error).toBe("Skipped: dependency 1 failed");
+  });
+
+  describe("[stories 23, 24, 25] graph-shape cascade", () => {
+    it("[story 23] wide fan-out: 1 parent failure cascades to all 10 waiting dependents with skip reason", async () => {
+      const workflow = await seedWorkflow();
+      const taskRepo = dataSource.getRepository(Task);
+
+      const parent = makeTask(workflow, 1, TaskStatus.Queued, null, "polygonArea", invalidGeoJson);
+      const dependents: Task[] = [];
+      for (let i = 0; i < 10; i++) {
+        dependents.push(makeTask(workflow, 2 + i, TaskStatus.Waiting, [1], "polygonArea"));
+      }
+      await taskRepo.save([parent, ...dependents]);
+
+      const runner = new TaskRunner(taskRepo);
+      await expect(runner.run(parent)).rejects.toThrow();
+
+      const parentAfter = await taskRepo.findOneByOrFail({ taskId: parent.taskId });
+      expect(parentAfter.status).toBe(TaskStatus.Failed);
+      expect(parentAfter.error).toBeTruthy();
+
+      for (const d of dependents) {
+        const after = await taskRepo.findOneByOrFail({ taskId: d.taskId });
+        expect(after.status).toBe(TaskStatus.Failed);
+        expect(after.progress).toBeNull();
+        expect(after.error).toBe("Skipped: dependency 1 failed");
+      }
+    });
+
+    it("[story 24] wide fan-in: only the step-5 failure cascades to the shared child, exactly once, referencing step 5", async () => {
+      const workflow = await seedWorkflow();
+      const taskRepo = dataSource.getRepository(Task);
+
+      const p1 = makeTask(workflow, 1, TaskStatus.Queued, null, "polygonArea", validGeoJson);
+      const p2 = makeTask(workflow, 2, TaskStatus.Queued, null, "polygonArea", validGeoJson);
+      const p3 = makeTask(workflow, 3, TaskStatus.Queued, null, "polygonArea", validGeoJson);
+      const p4 = makeTask(workflow, 4, TaskStatus.Queued, null, "polygonArea", validGeoJson);
+      const p5 = makeTask(workflow, 5, TaskStatus.Queued, null, "polygonArea", invalidGeoJson);
+      const child = makeTask(workflow, 6, TaskStatus.Waiting, [1, 2, 3, 4, 5], "notification");
+      await taskRepo.save([p1, p2, p3, p4, p5, child]);
+
+      const runner = new TaskRunner(taskRepo);
+      await runner.run(p1);
+      await runner.run(p2);
+      await runner.run(p3);
+      await runner.run(p4);
+
+      const childMid = await taskRepo.findOneByOrFail({ taskId: child.taskId });
+      expect(childMid.status).toBe(TaskStatus.Waiting);
+
+      const txSpy = vi.spyOn(taskRepo.manager, "transaction");
+      const p5Reload = await taskRepo.findOneOrFail({
+        where: { taskId: p5.taskId },
+        relations: ["workflow"],
+      });
+      await expect(runner.run(p5Reload)).rejects.toThrow();
+
+      // Failure path opens exactly one cascade transaction (no double-failure side effects).
+      expect(txSpy).toHaveBeenCalledTimes(1);
+
+      const p5After = await taskRepo.findOneByOrFail({ taskId: p5.taskId });
+      expect(p5After.status).toBe(TaskStatus.Failed);
+
+      const childAfter = await taskRepo.findOneByOrFail({ taskId: child.taskId });
+      expect(childAfter.status).toBe(TaskStatus.Failed);
+      expect(childAfter.progress).toBeNull();
+      expect(childAfter.error).toBe("Skipped: dependency 5 failed");
+    });
+
+    it("[story 25] two failure origins: descendant cascades once with reason referencing the lowest-stepNumber failed dependency", async () => {
+      const workflow = await seedWorkflow();
+      const taskRepo = dataSource.getRepository(Task);
+
+      const p1 = makeTask(workflow, 1, TaskStatus.Queued, null, "polygonArea", invalidGeoJson);
+      const p2 = makeTask(workflow, 2, TaskStatus.Queued, null, "polygonArea", invalidGeoJson);
+      const desc = makeTask(workflow, 3, TaskStatus.Waiting, [1, 2], "notification");
+      await taskRepo.save([p1, p2, desc]);
+
+      const runner = new TaskRunner(taskRepo);
+
+      await expect(runner.run(p1)).rejects.toThrow();
+
+      const descAfterP1 = await taskRepo.findOneByOrFail({ taskId: desc.taskId });
+      expect(descAfterP1.status).toBe(TaskStatus.Failed);
+      expect(descAfterP1.error).toBe("Skipped: dependency 1 failed");
+
+      const p2Reload = await taskRepo.findOneOrFail({
+        where: { taskId: p2.taskId },
+        relations: ["workflow"],
+      });
+      await expect(runner.run(p2Reload)).rejects.toThrow();
+
+      const p2After = await taskRepo.findOneByOrFail({ taskId: p2.taskId });
+      expect(p2After.status).toBe(TaskStatus.Failed);
+
+      // Descendant remains Failed with the original (lowest-step) reason; the
+      // step-2 failure does not re-cascade or overwrite the existing reason.
+      const descAfterP2 = await taskRepo.findOneByOrFail({ taskId: desc.taskId });
+      expect(descAfterP2.status).toBe(TaskStatus.Failed);
+      expect(descAfterP2.error).toBe("Skipped: dependency 1 failed");
+    });
   });
 });

--- a/tests/workers/taskRunner.errorPath.test.ts
+++ b/tests/workers/taskRunner.errorPath.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Error-path coverage for TaskRunner.
+ *
+ * Stories pinned in this file:
+ *  - story 17: malformed Task.dependency JSON must surface as a Failed task
+ *              (not silently swallowed) with a useful error message.
+ *  - story 18: invoking TaskRunner.run on a stale Queued task whose Workflow
+ *              is already Completed (with a non-null finalResult) preserves
+ *              the existing finalResult (no overwrite).
+ *  - story 41: a job that throws leaves Task.output untouched (null), so
+ *              downstream consumers cannot mistake a failure for success.
+ */
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { makeDataSource } from "../_support/makeDataSource";
+import { seedWorkflow } from "../_support/seedWorkflow";
+import { makeTask } from "../_support/makeTask";
+
+describe("TaskRunner error paths", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("[story 17] marks the task Failed when Task.dependency is malformed JSON", async () => {
+    const workflow = await seedWorkflow(dataSource, { status: WorkflowStatus.InProgress });
+    const taskRepo = dataSource.getRepository(Task);
+
+    const task = makeTask(workflow, 1, TaskStatus.Queued);
+    task.dependency = "{not-valid-json";
+    await taskRepo.save(task);
+
+    const runner = new TaskRunner(taskRepo);
+    await expect(runner.run(task)).rejects.toBeDefined();
+
+    const persisted = await taskRepo.findOneByOrFail({ taskId: task.taskId });
+    expect(persisted.status).toBe(TaskStatus.Failed);
+    expect(persisted.error).toBeTruthy();
+    const errMsg = (persisted.error ?? "").toLowerCase();
+    expect(errMsg.includes("json") || errMsg.includes("dependency")).toBe(true);
+  });
+
+  it("[story 18] does not overwrite a Workflow.finalResult that is already set", async () => {
+    const sentinelFinalResult = JSON.stringify({ sentinel: "original-final-result" });
+    const workflow = await seedWorkflow(dataSource, {
+      status: WorkflowStatus.Completed,
+      finalResult: sentinelFinalResult,
+    });
+    const taskRepo = dataSource.getRepository(Task);
+    const workflowRepo = dataSource.getRepository(Workflow);
+
+    const staleTask = makeTask(workflow, 1, TaskStatus.Queued);
+    await taskRepo.save(staleTask);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(staleTask);
+
+    const persistedWorkflow = await workflowRepo.findOneByOrFail({ workflowId: workflow.workflowId });
+    expect(persistedWorkflow.finalResult).toBe(sentinelFinalResult);
+    // LOCK: current behavior recomputes Workflow.status from the live task set.
+    // With a single now-Completed task, status stays Completed; this test pins
+    // that finalResult is preserved when already set. Re-evaluate if a future
+    // task tightens "stale-task immutability" semantics.
+    expect(persistedWorkflow.status).toBe(WorkflowStatus.Completed);
+  });
+
+  it("[story 41] leaves Task.output null when the underlying job throws", async () => {
+    const workflow = await seedWorkflow(dataSource, { status: WorkflowStatus.InProgress });
+    const taskRepo = dataSource.getRepository(Task);
+
+    const task = makeTask(workflow, 1, TaskStatus.Queued, { geoJson: "not json" });
+    await taskRepo.save(task);
+
+    const runner = new TaskRunner(taskRepo);
+    await expect(runner.run(task)).rejects.toBeDefined();
+
+    const persisted = await taskRepo.findOneByOrFail({ taskId: task.taskId });
+    expect(persisted.status).toBe(TaskStatus.Failed);
+    expect(persisted.output ?? null).toBeNull();
+  });
+});

--- a/tests/workers/taskRunner.lifecycle.test.ts
+++ b/tests/workers/taskRunner.lifecycle.test.ts
@@ -1,0 +1,109 @@
+/**
+ * TaskRunner lifecycle invariants — Workflow status promotion and dual-write
+ * of the per-task result payload.
+ *
+ * Stories pinned in this file:
+ *  - story 39: Workflow.status transitions Initial -> InProgress on the first
+ *              successful TaskRunner.run when the workflow still has un-run
+ *              dependent tasks (i.e. neither all-completed nor any-failed).
+ *  - story 40: On a successful task run, both Result.data and Task.output are
+ *              persisted with the same JSON-encoded job return value. This is
+ *              a deliberate marker test for the Result deprecation path
+ *              (per TESTING_PRD §"Further Notes") — the dual-write is the
+ *              current contract; if Result is later removed, this test will
+ *              fail loudly to force an explicit decision.
+ *
+ * All assertions read back from real persistence — no spies, no mocks.
+ */
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { makeDataSource } from "../_support/makeDataSource";
+import { seedWorkflow } from "../_support/seedWorkflow";
+import { makeTask } from "../_support/makeTask";
+
+describe("TaskRunner lifecycle: workflow promotion and result dual-write", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("[story 39] promotes workflow.status from Initial to InProgress when the first task completes but a dependent task remains", async () => {
+    const taskRepo = dataSource.getRepository(Task);
+    const workflowRepo = dataSource.getRepository(Workflow);
+
+    const workflow = await seedWorkflow(dataSource, {
+      status: WorkflowStatus.Initial,
+    });
+
+    const task1 = makeTask(workflow, 1, TaskStatus.Queued);
+    const task2 = makeTask(workflow, 2, TaskStatus.Waiting, {
+      dependency: [1],
+    });
+    await taskRepo.save([task1, task2]);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(task1);
+
+    const reloaded = await workflowRepo.findOneOrFail({
+      where: { workflowId: workflow.workflowId },
+      relations: ["tasks"],
+    });
+    expect(reloaded.status).toBe(WorkflowStatus.InProgress);
+
+    const reloadedTask1 = await taskRepo.findOneByOrFail({
+      taskId: task1.taskId,
+    });
+    expect(reloadedTask1.status).toBe(TaskStatus.Completed);
+
+    const reloadedTask2 = await taskRepo.findOneByOrFail({
+      taskId: task2.taskId,
+    });
+    expect(reloadedTask2.status).not.toBe(TaskStatus.Completed);
+    expect(reloadedTask2.status).not.toBe(TaskStatus.Failed);
+  });
+
+  it("[story 40] writes the same JSON-encoded job result to both Result.data and Task.output on success", async () => {
+    const taskRepo = dataSource.getRepository(Task);
+    const resultRepo = dataSource.getRepository(Result);
+
+    const workflow = await seedWorkflow(dataSource);
+
+    const task = makeTask(workflow, 1, TaskStatus.Queued);
+    await taskRepo.save(task);
+
+    const runner = new TaskRunner(taskRepo);
+    await runner.run(task);
+
+    const persistedTask = await taskRepo.findOneByOrFail({ taskId: task.taskId });
+    expect(persistedTask.status).toBe(TaskStatus.Completed);
+    expect(persistedTask.resultId).toBeTruthy();
+    expect(persistedTask.output).toBeTruthy();
+
+    const persistedResult = await resultRepo.findOneByOrFail({
+      resultId: persistedTask.resultId!,
+    });
+    expect(persistedResult.data).toBeTruthy();
+
+    const outputParsed = JSON.parse(persistedTask.output as string);
+    const dataParsed = JSON.parse(persistedResult.data as string);
+    expect(typeof outputParsed).toBe("number");
+    expect(typeof dataParsed).toBe("number");
+
+    expect(persistedResult.data).toBe(JSON.stringify(outputParsed));
+    expect(persistedTask.output).toBe(JSON.stringify(dataParsed));
+    expect(persistedResult.data).toBe(persistedTask.output);
+  });
+});

--- a/tests/workers/taskRunner.promotion.test.ts
+++ b/tests/workers/taskRunner.promotion.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Promotion coverage for TaskRunner.
+ *
+ * Stories pinned in this file:
+ *  - existing: Waiting → Queued promotion when single/multi-parent
+ *              dependencies complete, all within one manager.transaction.
+ *  - story 22: a 4-deep transitive dependency chain (A→B→C→D) is promoted
+ *              one level per TaskRunner.run call; intermediate steps stay
+ *              Waiting until their direct parent completes.
+ */
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { DataSource } from "typeorm";
@@ -6,6 +16,9 @@ import { Result } from "../../src/models/Result";
 import { Workflow } from "../../src/models/Workflow";
 import { TaskRunner, TaskStatus } from "../../src/workers/taskRunner";
 import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { makeDataSource } from "../_support/makeDataSource";
+import { seedWorkflow as seedWorkflowSupport } from "../_support/seedWorkflow";
+import { makeTask as makeTaskSupport } from "../_support/makeTask";
 
 describe("TaskRunner promotes Waiting children when dependencies complete", () => {
   let dataSource: DataSource;
@@ -124,5 +137,67 @@ describe("TaskRunner promotes Waiting children when dependencies complete", () =
     const childAfter = await taskRepo.findOneByOrFail({ taskId: child.taskId });
     expect(parentAfter.status).toBe(TaskStatus.Completed);
     expect(childAfter.status).toBe(TaskStatus.Queued);
+  });
+});
+
+describe("[story 22] transitive chain promotion", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("[story 22] promotes a 4-deep dependency chain one level per TaskRunner.run call", async () => {
+    const workflow = await seedWorkflowSupport(dataSource);
+    const taskRepo = dataSource.getRepository(Task);
+
+    const a = makeTaskSupport(workflow, 1, TaskStatus.Queued, { dependency: null });
+    const b = makeTaskSupport(workflow, 2, TaskStatus.Waiting, { dependency: [1] });
+    const c = makeTaskSupport(workflow, 3, TaskStatus.Waiting, { dependency: [2] });
+    const d = makeTaskSupport(workflow, 4, TaskStatus.Waiting, { dependency: [3] });
+    await taskRepo.save([a, b, c, d]);
+
+    const runner = new TaskRunner(taskRepo);
+
+    await runner.run(a);
+
+    let aAfter = await taskRepo.findOneByOrFail({ taskId: a.taskId });
+    let bAfter = await taskRepo.findOneByOrFail({ taskId: b.taskId });
+    let cAfter = await taskRepo.findOneByOrFail({ taskId: c.taskId });
+    let dAfter = await taskRepo.findOneByOrFail({ taskId: d.taskId });
+    expect(aAfter.status).toBe(TaskStatus.Completed);
+    expect(bAfter.status).toBe(TaskStatus.Queued);
+    expect(cAfter.status).toBe(TaskStatus.Waiting);
+    expect(dAfter.status).toBe(TaskStatus.Waiting);
+
+    const bReload = await taskRepo.findOneOrFail({ where: { taskId: b.taskId }, relations: ["workflow"] });
+    await runner.run(bReload);
+
+    bAfter = await taskRepo.findOneByOrFail({ taskId: b.taskId });
+    cAfter = await taskRepo.findOneByOrFail({ taskId: c.taskId });
+    dAfter = await taskRepo.findOneByOrFail({ taskId: d.taskId });
+    expect(bAfter.status).toBe(TaskStatus.Completed);
+    expect(cAfter.status).toBe(TaskStatus.Queued);
+    expect(dAfter.status).toBe(TaskStatus.Waiting);
+
+    const cReload = await taskRepo.findOneOrFail({ where: { taskId: c.taskId }, relations: ["workflow"] });
+    await runner.run(cReload);
+
+    cAfter = await taskRepo.findOneByOrFail({ taskId: c.taskId });
+    dAfter = await taskRepo.findOneByOrFail({ taskId: d.taskId });
+    expect(cAfter.status).toBe(TaskStatus.Completed);
+    expect(dAfter.status).toBe(TaskStatus.Queued);
+
+    const dReload = await taskRepo.findOneOrFail({ where: { taskId: d.taskId }, relations: ["workflow"] });
+    await runner.run(dReload);
+
+    dAfter = await taskRepo.findOneByOrFail({ taskId: d.taskId });
+    expect(dAfter.status).toBe(TaskStatus.Completed);
   });
 });

--- a/tests/workers/taskRunner.scale.test.ts
+++ b/tests/workers/taskRunner.scale.test.ts
@@ -1,0 +1,153 @@
+/**
+ * TaskRunner-at-scale graph-shape coverage.
+ *
+ * Stories pinned in this file:
+ *  - story 31: 100-task fan-in completes — 99 analysis leaves + 1
+ *              reportGeneration aggregator (deps [1..99]); after a full
+ *              drain every task is Completed and the workflow is
+ *              Completed with finalResult populated.
+ *  - story 32: 100-task fan-in with one failed leaf — same shape as
+ *              story 31, but leaf step 50 is a polygonArea task with
+ *              invalid GeoJSON. The aggregator (step 100) is cascaded
+ *              to Failed with `Skipped: dependency 50 failed`, and the
+ *              workflow.finalResult.tasks array contains all 100
+ *              entries ordered by stepNumber.
+ *  - story 33: 50-deep linear chain completes — 50 analysis tasks where
+ *              each step N depends on step N-1; after a full drain
+ *              every step is Completed (no Waiting/Queued/InProgress
+ *              residue).
+ */
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskStatus } from "../../src/workers/taskRunner";
+import { WorkflowStatus } from "../../src/workflows/WorkflowFactory";
+import { makeDataSource } from "../_support/makeDataSource";
+import { seedWorkflow } from "../_support/seedWorkflow";
+import { makeTask } from "../_support/makeTask";
+import { drainQueuedTasks } from "../_support/drainQueuedTasks";
+
+describe("TaskRunner at scale (fan-in & deep chain graph shapes)", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("[story 31] 100-task fan-in (99 analysis leaves + 1 reportGeneration) completes with all tasks Completed", async () => {
+    const workflow = await seedWorkflow(dataSource);
+    const taskRepo = dataSource.getRepository(Task);
+
+    const tasks: Task[] = [];
+    for (let step = 1; step <= 99; step++) {
+      tasks.push(makeTask(workflow, step, TaskStatus.Queued, { taskType: "analysis" }));
+    }
+    const leafSteps = Array.from({ length: 99 }, (_, i) => i + 1);
+    tasks.push(makeTask(workflow, 100, TaskStatus.Waiting, {
+      taskType: "reportGeneration",
+      dependency: leafSteps,
+    }));
+    await taskRepo.save(tasks);
+
+    await drainQueuedTasks(dataSource);
+
+    const allAfter = await taskRepo.find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+    });
+    expect(allAfter).toHaveLength(100);
+    for (const t of allAfter) {
+      expect(t.status).toBe(TaskStatus.Completed);
+    }
+
+    const wfRepo = dataSource.getRepository(Workflow);
+    const wfAfter = await wfRepo.findOneByOrFail({ workflowId: workflow.workflowId });
+    expect(wfAfter.status).toBe(WorkflowStatus.Completed);
+    expect(wfAfter.finalResult).toBeTruthy();
+    const parsed = JSON.parse(wfAfter.finalResult as string);
+    expect(parsed.totalTasks).toBe(100);
+    expect(parsed.completedTasks).toBe(100);
+  });
+
+  it("[story 32] 100-task fan-in with leaf step 50 failing cascades the aggregator and writes a 100-entry finalResult", async () => {
+    const workflow = await seedWorkflow(dataSource);
+    const taskRepo = dataSource.getRepository(Task);
+
+    const failingStep = 50;
+    const tasks: Task[] = [];
+    for (let step = 1; step <= 99; step++) {
+      if (step === failingStep) {
+        tasks.push(makeTask(workflow, step, TaskStatus.Queued, {
+          taskType: "polygonArea",
+          geoJson: "this is not json",
+        }));
+      } else {
+        tasks.push(makeTask(workflow, step, TaskStatus.Queued, { taskType: "analysis" }));
+      }
+    }
+    const leafSteps = Array.from({ length: 99 }, (_, i) => i + 1);
+    tasks.push(makeTask(workflow, 100, TaskStatus.Waiting, {
+      taskType: "reportGeneration",
+      dependency: leafSteps,
+    }));
+    await taskRepo.save(tasks);
+
+    await drainQueuedTasks(dataSource);
+
+    const failingLeaf = await taskRepo.findOneByOrFail({ taskId: tasks[failingStep - 1].taskId });
+    expect(failingLeaf.status).toBe(TaskStatus.Failed);
+    expect(failingLeaf.error).toBeTruthy();
+
+    const aggregator = await taskRepo.findOneByOrFail({ taskId: tasks[99].taskId });
+    expect(aggregator.stepNumber).toBe(100);
+    expect(aggregator.status).toBe(TaskStatus.Failed);
+    expect(aggregator.error).toBe(`Skipped: dependency ${failingStep} failed`);
+
+    const wfRepo = dataSource.getRepository(Workflow);
+    const wfAfter = await wfRepo.findOneByOrFail({ workflowId: workflow.workflowId });
+    expect(wfAfter.status).toBe(WorkflowStatus.Failed);
+    expect(wfAfter.finalResult).toBeTruthy();
+    const parsed = JSON.parse(wfAfter.finalResult as string);
+    expect(parsed.tasks).toHaveLength(100);
+    expect(parsed.tasks.map((t: any) => t.stepNumber)).toEqual(
+      Array.from({ length: 100 }, (_, i) => i + 1),
+    );
+  });
+
+  it("[story 33] 50-deep linear analysis chain completes with every step Completed", async () => {
+    const workflow = await seedWorkflow(dataSource);
+    const taskRepo = dataSource.getRepository(Task);
+
+    const tasks: Task[] = [];
+    tasks.push(makeTask(workflow, 1, TaskStatus.Queued, { taskType: "analysis" }));
+    for (let step = 2; step <= 50; step++) {
+      tasks.push(makeTask(workflow, step, TaskStatus.Waiting, {
+        taskType: "analysis",
+        dependency: [step - 1],
+      }));
+    }
+    await taskRepo.save(tasks);
+
+    await drainQueuedTasks(dataSource);
+
+    const allAfter = await taskRepo.find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+      order: { stepNumber: "ASC" },
+    });
+    expect(allAfter).toHaveLength(50);
+    for (const t of allAfter) {
+      expect(t.status).toBe(TaskStatus.Completed);
+    }
+    expect(allAfter[0].status).toBe(TaskStatus.Completed);
+    expect(allAfter[49].status).toBe(TaskStatus.Completed);
+  });
+});

--- a/tests/workflows/WorkflowFactory.deps.test.ts
+++ b/tests/workflows/WorkflowFactory.deps.test.ts
@@ -1,3 +1,20 @@
+/**
+ * Tests for `WorkflowFactory.createWorkflowFromYAML`.
+ *
+ * Covers TESTING_PRD stories:
+ *   - story 6  (existing): dependsOn YAML → Task.dependency JSON form
+ *   - story 16 (this file): PIN current permissive behavior for malformed
+ *                            YAML (cycle / duplicate stepNumber / dangling
+ *                            dep / missing `steps` key). LOCK semantics —
+ *                            see TESTING_PRD §"Further Notes". The factory
+ *                            performs no cycle / duplicate / dangling-dep /
+ *                            missing-steps validation today; these tests
+ *                            make that absence observable so that any
+ *                            future commit which adds validation has to
+ *                            update them intentionally.
+ *   - story 29 (this file): tasks persist with stepNumbers + dependency
+ *                            JSON driven by YAML content, not file order.
+ */
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
@@ -9,6 +26,7 @@ import { Result } from "../../src/models/Result";
 import { Workflow } from "../../src/models/Workflow";
 import { WorkflowFactory } from "../../src/workflows/WorkflowFactory";
 import { TaskStatus } from "../../src/workers/taskRunner";
+import { makeDataSource } from "../_support/makeDataSource";
 
 describe("WorkflowFactory dependsOn parsing", () => {
   let dataSource: DataSource;
@@ -102,5 +120,178 @@ describe("WorkflowFactory dependsOn parsing", () => {
       expect(t.dependency ?? null).toBeNull();
       expect(t.status).toBe(TaskStatus.Queued);
     }
+  });
+});
+
+describe("[stories 16, 29] permissive YAML + stepNumber ordering", () => {
+  let dataSource: DataSource;
+  let tmpFiles: string[] = [];
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+    for (const f of tmpFiles) {
+      try { fs.unlinkSync(f); } catch { /* ignore */ }
+    }
+    tmpFiles = [];
+  });
+
+  function writeYaml(content: string): string {
+    const p = path.join(os.tmpdir(), `wf-${Date.now()}-${Math.random()}.yml`);
+    fs.writeFileSync(p, content, "utf8");
+    tmpFiles.push(p);
+    return p;
+  }
+
+  const geoJson = JSON.stringify({
+    type: "Polygon",
+    coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+  });
+
+  it("[story 16] persists a 2-step cycle (1↔2) without rejecting it", async () => {
+    // LOCK: documents current permissive behavior — see TESTING_PRD §"Further Notes"
+    const yamlPath = writeYaml(
+      [
+        'name: "cycle_workflow"',
+        "steps:",
+        '  - taskType: "polygonArea"',
+        "    stepNumber: 1",
+        "    dependsOn: [2]",
+        '  - taskType: "polygonArea"',
+        "    stepNumber: 2",
+        "    dependsOn: [1]",
+      ].join("\n"),
+    );
+
+    const factory = new WorkflowFactory(dataSource);
+    const workflow = await factory.createWorkflowFromYAML(yamlPath, "client-cycle", geoJson);
+
+    const tasks = await dataSource.getRepository(Task).find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+    });
+    const byStep = new Map(tasks.map(t => [t.stepNumber, t]));
+
+    expect(tasks).toHaveLength(2);
+    expect(byStep.get(1)?.dependency).toBe(JSON.stringify([2]));
+    expect(byStep.get(1)?.status).toBe(TaskStatus.Waiting);
+    expect(byStep.get(2)?.dependency).toBe(JSON.stringify([1]));
+    expect(byStep.get(2)?.status).toBe(TaskStatus.Waiting);
+  });
+
+  it("[story 16] persists duplicate stepNumber rows without de-duplicating", async () => {
+    // LOCK: documents current permissive behavior — see TESTING_PRD §"Further Notes"
+    const yamlPath = writeYaml(
+      [
+        'name: "dup_step_workflow"',
+        "steps:",
+        '  - taskType: "polygonArea"',
+        "    stepNumber: 1",
+        '  - taskType: "notification"',
+        "    stepNumber: 1",
+      ].join("\n"),
+    );
+
+    const factory = new WorkflowFactory(dataSource);
+    const workflow = await factory.createWorkflowFromYAML(yamlPath, "client-dup", geoJson);
+
+    const tasks = await dataSource.getRepository(Task).find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+    });
+
+    expect(tasks).toHaveLength(2);
+    expect(tasks.every(t => t.stepNumber === 1)).toBe(true);
+    const taskTypes = tasks.map(t => t.taskType).sort();
+    expect(taskTypes).toEqual(["notification", "polygonArea"]);
+    for (const t of tasks) {
+      expect(t.dependency ?? null).toBeNull();
+      expect(t.status).toBe(TaskStatus.Queued);
+    }
+  });
+
+  it("[story 16] persists a dangling dep ([99] with no such step) verbatim", async () => {
+    // LOCK: documents current permissive behavior — see TESTING_PRD §"Further Notes"
+    const yamlPath = writeYaml(
+      [
+        'name: "dangling_dep_workflow"',
+        "steps:",
+        '  - taskType: "polygonArea"',
+        "    stepNumber: 1",
+        "    dependsOn: [99]",
+      ].join("\n"),
+    );
+
+    const factory = new WorkflowFactory(dataSource);
+    const workflow = await factory.createWorkflowFromYAML(yamlPath, "client-dangling", geoJson);
+
+    const tasks = await dataSource.getRepository(Task).find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+    });
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].stepNumber).toBe(1);
+    expect(tasks[0].dependency).toBe(JSON.stringify([99]));
+    expect(tasks[0].status).toBe(TaskStatus.Waiting);
+  });
+
+  it("[story 16] throws when YAML omits the `steps` key entirely", async () => {
+    // LOCK: documents current permissive behavior — see TESTING_PRD §"Further Notes"
+    // No defensive guard around `workflowDef.steps.map(...)`, so a missing
+    // `steps` key surfaces as a TypeError from the .map() call rather than
+    // a domain-specific validation error.
+    const yamlPath = writeYaml('name: "x"\n');
+
+    const factory = new WorkflowFactory(dataSource);
+    await expect(
+      factory.createWorkflowFromYAML(yamlPath, "client-missing-steps", geoJson),
+    ).rejects.toThrow(TypeError);
+  });
+
+  it("[story 29] persists tasks with stepNumbers + dependency JSON driven by YAML content, not file order", async () => {
+    // YAML lists steps in file order [3, 1, 2] but defines a chain 1 → 2 → 3
+    // via dependsOn. Ordering is content-driven (stepNumber + dependsOn),
+    // not file-position driven.
+    const yamlPath = writeYaml(
+      [
+        'name: "ordered_workflow"',
+        "steps:",
+        '  - taskType: "polygonArea"',
+        "    stepNumber: 3",
+        "    dependsOn: [2]",
+        '  - taskType: "polygonArea"',
+        "    stepNumber: 1",
+        '  - taskType: "polygonArea"',
+        "    stepNumber: 2",
+        "    dependsOn: [1]",
+      ].join("\n"),
+    );
+
+    const factory = new WorkflowFactory(dataSource);
+    const workflow = await factory.createWorkflowFromYAML(yamlPath, "client-ordered", geoJson);
+
+    const tasks = await dataSource.getRepository(Task).find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+    });
+    const byStep = new Map(tasks.map(t => [t.stepNumber, t]));
+
+    expect(tasks).toHaveLength(3);
+    expect([...byStep.keys()].sort()).toEqual([1, 2, 3]);
+
+    expect(byStep.get(1)?.dependency ?? null).toBeNull();
+    expect(byStep.get(1)?.status).toBe(TaskStatus.Queued);
+
+    expect(byStep.get(2)?.dependency).toBe(JSON.stringify([1]));
+    expect(byStep.get(2)?.status).toBe(TaskStatus.Waiting);
+
+    expect(byStep.get(3)?.dependency).toBe(JSON.stringify([2]));
+    expect(byStep.get(3)?.status).toBe(TaskStatus.Waiting);
   });
 });

--- a/tests/workflows/WorkflowFactory.scale.test.ts
+++ b/tests/workflows/WorkflowFactory.scale.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Scale test for `WorkflowFactory.createWorkflowFromYAML`.
+ *
+ * Covers TESTING_PRD stories:
+ *   - story 30: parses + persists a 100-step YAML graph with mixed dependencies.
+ *
+ * YAML shape:
+ *   - Linear chain across steps 1..99 (step 1 has no deps; step k>1 depends
+ *     on step k-1) — produced via buildLinearChainYaml(99) from
+ *     tests/_support/buildYaml.ts.
+ *   - Fan-in spine: step 100 (`reportGeneration`) depends on every odd step
+ *     in [1, 3, 5, …, 99] — appended inline because the existing helpers
+ *     don't compose into this exact shape.
+ *
+ * Per TESTING_PRD Q13: NO wall-clock assertion — duration is informational.
+ */
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { WorkflowFactory } from "../../src/workflows/WorkflowFactory";
+import { TaskStatus } from "../../src/workers/taskRunner";
+import { makeDataSource } from "../_support/makeDataSource";
+import { buildLinearChainYaml } from "../_support/buildYaml";
+
+describe("[story 30] WorkflowFactory at 100 steps", () => {
+  let dataSource: DataSource;
+  let tmpFiles: string[] = [];
+
+  beforeEach(async () => {
+    dataSource = await makeDataSource();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+    for (const f of tmpFiles) {
+      try { fs.unlinkSync(f); } catch { /* ignore */ }
+    }
+    tmpFiles = [];
+  });
+
+  function writeYaml(content: string): string {
+    const p = path.join(os.tmpdir(), `wf-scale-${Date.now()}-${Math.random()}.yml`);
+    fs.writeFileSync(p, content, "utf8");
+    tmpFiles.push(p);
+    return p;
+  }
+
+  const geoJson = JSON.stringify({
+    type: "Polygon",
+    coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+  });
+
+  it("[story 30] parses + persists 100-step YAML with mixed dependencies", async () => {
+    const oddSteps = Array.from({ length: 50 }, (_, i) => 2 * i + 1); // [1, 3, …, 99]
+    const chain = buildLinearChainYaml(99); // steps 1..99 linear chain
+    const fanInLines = [
+      `  - taskType: "reportGeneration"`,
+      `    stepNumber: 100`,
+      `    dependsOn: [${oddSteps.join(", ")}]`,
+      "",
+    ].join("\n");
+    const yamlPath = writeYaml(chain + fanInLines);
+
+    const factory = new WorkflowFactory(dataSource);
+    const start = Date.now();
+    const workflow = await factory.createWorkflowFromYAML(yamlPath, "client-scale", geoJson);
+    const elapsedMs = Date.now() - start;
+    // eslint-disable-next-line no-console
+    console.log(`[story 30] createWorkflowFromYAML(100 steps) took ${elapsedMs}ms`);
+
+    const tasks = await dataSource.getRepository(Task).find({
+      where: { workflow: { workflowId: workflow.workflowId } },
+      relations: ["workflow"],
+    });
+    const byStep = new Map(tasks.map(t => [t.stepNumber, t]));
+
+    expect(tasks).toHaveLength(100);
+    expect([...byStep.keys()].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 100 }, (_, i) => i + 1),
+    );
+
+    expect(byStep.get(1)?.dependency ?? null).toBeNull();
+    expect(byStep.get(1)?.status).toBe(TaskStatus.Queued);
+
+    for (let k = 2; k <= 99; k++) {
+      const t = byStep.get(k);
+      expect(t).toBeDefined();
+      expect(t!.dependency).not.toBeNull();
+      expect(JSON.parse(t!.dependency as string)).toEqual([k - 1]);
+      expect(t!.status).toBe(TaskStatus.Waiting);
+    }
+
+    const step100 = byStep.get(100);
+    expect(step100).toBeDefined();
+    expect(step100!.dependency).not.toBeNull();
+    expect(JSON.parse(step100!.dependency as string)).toEqual(oddSteps);
+    expect(step100!.status).toBe(TaskStatus.Waiting);
+    expect(step100!.taskType).toBe("reportGeneration");
+  });
+});

--- a/tests/workflows/workflowSummary.test.ts
+++ b/tests/workflows/workflowSummary.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the pure `workflowSummary` projection.
+ *
+ * Covers:
+ *   - core shape + counts (existing cases)
+ *   - story 28: mid-flight workflow with all 5 task statuses present
+ *   - story 34: 100-task scale workflow with mixed statuses (no truncation)
+ */
 import { describe, it, expect } from "vitest";
 import { workflowSummary } from "../../src/workflows/workflowSummary";
 
@@ -271,3 +279,102 @@ describe("workflowSummary", () => {
     });
   });
 });
+
+describe("[stories 28, 34] mid-flight + scale", () => {
+  it("[story 28] summarises a workflow with one task in each of the 5 statuses (mid-flight shape stable, ordered by stepNumber)", () => {
+    // Insertion order intentionally scrambled to verify ordering by stepNumber.
+    const workflow = {
+      workflowId: "wf-mid-flight",
+      status: "in_progress",
+      tasks: [
+        { taskId: "t-q", stepNumber: 2, taskType: "polygonArea", status: "queued" },
+        { taskId: "t-c", stepNumber: 4, taskType: "polygonArea", status: "completed", output: JSON.stringify(123) },
+        { taskId: "t-w", stepNumber: 1, taskType: "polygonArea", status: "waiting" },
+        { taskId: "t-f", stepNumber: 5, taskType: "polygonArea", status: "failed", error: "boom" },
+        { taskId: "t-p", stepNumber: 3, taskType: "polygonArea", status: "in_progress", progress: "halfway" },
+      ],
+    } as any;
+
+    const result = workflowSummary(workflow, { includeTasks: true });
+
+    // Shape stability: exact top-level keys, no extras.
+    expect(Object.keys(result).sort()).toEqual(
+      ["completedTasks", "status", "tasks", "totalTasks", "workflowId"],
+    );
+    expect(result.workflowId).toBe("wf-mid-flight");
+    expect(result.status).toBe("in_progress");
+    expect(result.completedTasks).toBe(1);
+    expect(result.totalTasks).toBe(5);
+
+    // tasks[] must be ordered by stepNumber regardless of input order.
+    expect(result.tasks?.map(t => t.stepNumber)).toEqual([1, 2, 3, 4, 5]);
+    expect(result.tasks?.map(t => t.taskId)).toEqual(["t-w", "t-q", "t-p", "t-c", "t-f"]);
+    expect(result.tasks?.map(t => t.status)).toEqual([
+      "waiting",
+      "queued",
+      "in_progress",
+      "completed",
+      "failed",
+    ]);
+  });
+
+  it("[story 34] summarises a 100-task workflow without truncation; completedTasks matches a manual reduce over the seed", () => {
+    // Deterministic seed: ~half completed, the rest split across failed/queued/waiting/in_progress.
+    const seed = Array.from({ length: 100 }, (_, i) => {
+      const stepNumber = i + 1;
+      const mod = i % 5;
+      if (mod === 0 || mod === 1 || mod === 2) {
+        // 60 completed (indexes 0,1,2,5,6,7,...)
+        return {
+          taskId: `t-${stepNumber}`,
+          stepNumber,
+          taskType: "polygonArea",
+          status: "completed",
+          output: JSON.stringify({ step: stepNumber }),
+        };
+      }
+      if (mod === 3) {
+        return {
+          taskId: `t-${stepNumber}`,
+          stepNumber,
+          taskType: "polygonArea",
+          status: "failed",
+          error: `failure-${stepNumber}`,
+        };
+      }
+      // mod === 4 → cycle through the three non-terminal statuses
+      const cycle = ["queued", "waiting", "in_progress"][stepNumber % 3];
+      return {
+        taskId: `t-${stepNumber}`,
+        stepNumber,
+        taskType: "polygonArea",
+        status: cycle,
+      };
+    });
+
+    // Shuffle insertion order so the projection has to re-sort.
+    const shuffled = [...seed].reverse();
+    const workflow = {
+      workflowId: "wf-scale-100",
+      status: "in_progress",
+      tasks: shuffled,
+    } as any;
+
+    const expectedCompleted = seed.reduce(
+      (acc, t) => acc + (t.status === "completed" ? 1 : 0),
+      0,
+    );
+
+    const result = workflowSummary(workflow, { includeTasks: true });
+
+    expect(result.totalTasks).toBe(100);
+    expect(result.completedTasks).toBe(expectedCompleted);
+    expect(result.tasks).toBeDefined();
+    expect(result.tasks?.length).toBe(100); // no truncation
+
+    // tasks[] strictly ordered by stepNumber 1..100.
+    const stepNumbers = result.tasks?.map(t => t.stepNumber) ?? [];
+    expect(stepNumbers).toEqual(Array.from({ length: 100 }, (_, i) => i + 1));
+  });
+});
+


### PR DESCRIPTION
## Summary

Implements the full TESTING_PRD coverage plan: **30 new test cases** across **16 files** closing happy-path, error-path, graph edge-case, and scale gaps in the workflow engine, plus **3 targeted production fixes** surfaced via RED tests.

- **Tests:** 20 files / 104 tests / ~2.10s — all green
- **Stories covered:** 30 / 30 (TESTING_PRD §12–41)
- **Methodology:** RED-GREEN-REFACTOR per `CLAUDE.md`; `npm test` green at every commit
- **Constraints upheld:** No wall-clock assertions, no production-behavior mocks, file-top JSDoc + `[story N]` it-prefixes throughout

## Production code changes (3 files)

| File | Wave | Change |
|---|---|---|
| `src/jobs/PolygonAreaJob.ts` | 1a | `validatePolygonRings` helper — rejects rings <4 coords, unclosed rings, MultiPolygon variants, non-array coordinates. Closes silent `area=0` on invalid GeoJSON. |
| `src/workers/taskRunner.ts` | 2a | `buildJobContext` now throws on malformed `Task.dependency` JSON instead of returning `undefined`; call moved inside `run()`'s try-block so failures route through the existing Failed path. |
| `src/routes/workflowRoutes.ts` | 2g | `GET /:id/results` returns 500 when terminal workflow has `finalResult=null` instead of `200 OK` with body `null`. |

No other `src/` files modified.

## Wave timeline (17 commits)

| Wave | Scope | Stories |
|---|---|---|
| 0 | Shared test helpers (`tests/_support/`) | — |
| 1a–f | Jobs + WorkflowFactory + workflowSummary | 12, 13, 14, 15, 16, 28, 29, 30, 34 |
| 2a–g | Workers + Routes (incl. 3 prod fixes) | 17–27, 31–33, 35, 39, 40, 41 |
| 3a–c | Integration E2E via supertest | 36, 37, 38 |
| 4 | Final verification + story-to-file mapping | — |

Each wave was paired with a dedicated verifier agent before the next wave started.

## LOCK tests (intentional)

Stories 16, 26, 27 are explicitly **LOCK tests** that pin current permissive YAML behaviour and single-pass reconcile semantics. A future hardening commit (YAML cycle/dup/dangling-dep validation; fixed-point reconciliation) should deliberately update them. This is by design per `TESTING_PRD §Further Notes`.

## How to verify

```bash
npm test        # 20 files / 104 tests, ~2.1s
```

## Notes

- The lone pre-existing `vi.mock` of `JobFactory` in `tests/workers/taskRunner.context.test.ts` is unchanged from baseline (zero diff) and explicitly sanctioned by TESTING_PRD §Testing Decisions.
- All 16 added/extended test files use real entities + in-memory SQLite via `makeDataSource` from `tests/_support/`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author